### PR TITLE
An attempt at a pytorch fast_inla implementation.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 # essentials
-  - python
+  - python=3.9
   - setuptools
   - jupyterlab
   - numpy

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = -s --tb=short
 norecursedirs = __pycache__ build bazel-*
+env = 
+    PYTORCH_ENABLE_MPS_FALLBACK=1

--- a/research/berry/berrylib/benchmark.py
+++ b/research/berry/berrylib/benchmark.py
@@ -1,0 +1,38 @@
+# flake8: noqa
+import sys
+import time
+
+sys.path.append("./research/berry")
+import berrylib.fast_inla as fast_inla
+import test_berry
+import torch
+
+
+def benchmark_m1_torch():
+    for device in ["cpu", "mps"]:
+        print("")
+        start = time.time()
+        N = 5000
+        A = torch.rand(N, N, dtype=torch.float).to(device)
+        B = torch.rand(N, N, dtype=torch.float).to(device)
+        print("create", time.time() - start)
+
+        start = time.time()
+        for i in range(100):
+            A = torch.mm(A, B) * (2 / N)
+        cpu_arr = A.to("cpu")
+        print(cpu_arr[0, 0], cpu_arr[-1, -1])
+        print("matvec", time.time() - start)
+        start = time.time()
+
+
+N = 10000
+it = 4
+print("jax")
+test_berry.test_fast_inla("jax", N, it)
+# print("cpp")
+# test_berry.test_fast_inla("cpp", N, it)
+# print("numpy")
+# test_berry.test_fast_inla("numpy", N, it)
+print("pytorch")
+test_berry.test_fast_inla("pytorch", N, it)

--- a/research/berry/berrylib/test_berry.py
+++ b/research/berry/berrylib/test_berry.py
@@ -167,11 +167,14 @@ def test_inla_properties(method):
     np.testing.assert_allclose(sigma2_integral, 1.0)
 
 
-@pytest.mark.parametrize("method", ["jax", "numpy", "cpp"])
+@pytest.mark.parametrize("method", ["pytorch"])
 def test_fast_inla(method, N=10, iterations=1):
     n_i = np.tile(np.array([20, 20, 35, 35]), (N, 1))
     y_i = np.tile(np.array([0, 1, 9, 10], dtype=np.float64), (N, 1))
     inla_model = fast_inla.FastINLA()
+
+    # import torch
+    # inla_model = fast_inla.FastINLA(torch_dtype=torch.float32, torch_device='mps')
 
     runtimes = []
     for i in range(iterations):
@@ -187,10 +190,28 @@ def test_fast_inla(method, N=10, iterations=1):
 
     sigma2_post, exceedances, theta_max, theta_sigma = out
 
-    np.testing.assert_allclose(
-        theta_max[0, 12],
+    correct_theta_max = [
+        [-0.65720195, -0.65720081, -0.65719484, -0.65719371],
+        [-0.65720546, -0.65720355, -0.65719345, -0.65719153],
+        [-0.65721851, -0.65721369, -0.65718827, -0.65718345],
+        [-0.65727494, -0.65725755, -0.65716589, -0.65714851],
+        [-0.65757963, -0.65749441, -0.65704505, -0.65695985],
+        [-0.65958489, -0.65905323, -0.65625057, -0.65571955],
+        [-0.67465157, -0.67076447, -0.65032674, -0.64647392],
+        [-0.78705011, -0.75796462, -0.60851132, -0.58150985],
+        [-1.34091076, -1.17062088, -0.44985596, -0.34985839],
+        [-2.47957009, -1.79535068, -0.28588712, -0.14714995],
+        [-3.7880899, -2.05159198, -0.23025555, -0.08632545],
+        [-5.02345932, -2.09158471, -0.21765884, -0.07316777],
         [-6.04682818, -2.09586893, -0.21474981, -0.07019088],
-        rtol=1e-3,
+        [-6.789137, -2.09644905, -0.21401509, -0.06944441],
+        [-7.21806318, -2.096633, -0.21382083, -0.06924673],
+    ]
+    print(theta_max[0])
+    np.testing.assert_allclose(
+        theta_max[0],
+        correct_theta_max,
+        rtol=1e-2,
     )
     correct = np.array(
         [


### PR DESCRIPTION
I played a bunch with pytorch over the last day. Overall, my conclusion is pretty negative in comparison with jax. I’m going to record my explorations in the repo because it’s still worth doing another look once we start playing with GPU stuff more.

Overall:
* I can’t get a float64 CPU version of pytorch to be competitive with JAX. It’s about 3x slower (21us vs 7us). This isn’t a huge deal since neither of these numbers is slow, but it is disappointing since that’s the relevant comparison.
* Using the M1 GPU/Apple metal backend is REALLY messy. The backend is quite immature and seems to only really support standard neural net operations well. 
  * Some things are a lot faster. For example, with v1.13 (the version that enables the “mps” mac gpu backend), I get about a 10x speedup compared to v1.11 for something like a simple matrix multiply. That’s awesome and really important since matmuls are so fundamental.
  * But, what we need is a bit more complex and several of the important operations are not supported yet by the mps backend. determinants, matrix solves and inverses. a few others.
  * Several operations ran but returned incorrect output. torch.einsum and torch.linalg.inv just gave completely incorrect output. I made an issue: https://github.com/pytorch/pytorch/issues/78363
* The other big issue is that running with the metal backend requires running in float32 (this would be true of cuda too, at least for good performance). It turns out that this causes major problems for our current Berry fast_inla code. A few of our operations fail in 32 bit floating point. The INLA optimization to find the mode fails to converge because the hessian inverse is unstable particularly for small sigma2. If I use a linear solver instead of computing the inverse directly, I can get float32 to work correctly. But that means it’s nontrivially harder to get the variance of the multivariate gaussian approximation. Anyway, this is probably another set of issues that we’ll need to explore a bit more in the future. Being able to do correct inference in 32 bit floating point precision would be really helpful for performance because it unlocks the whole GPU world. I don’t think I should dig into it more right now because it’s not critical path, but it’s good to know what kind of problems we might run into. 