### PR TITLE
Use matrix determinant lemma instead of pivoting

### DIFF
--- a/research/berry/jax_inla.ipynb
+++ b/research/berry/jax_inla.ipynb
@@ -1,982 +1,956 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/const/mambaforge/envs/kevlar/lib/python3.10/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "import sys\n",
-    "\n",
-    "import jax\n",
-    "import jax.numpy as jnp\n",
-    "import numpyro.distributions as dist\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "\n",
-    "from berrylib.constants import Y_I, Y_I2, N_I, N_I2\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 160,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "10000\n",
-      "20000\n",
-      "30000\n",
-      "40000\n",
-      "50000\n",
-      "60000\n",
-      "70000\n",
-      "80000\n",
-      "90000\n"
-     ]
+    "cells": [{
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [{
+                "name": "stderr",
+                "output_type": "stream",
+                "text": [
+                    "/home/const/mambaforge/envs/kevlar/lib/python3.10/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+                    "  from .autonotebook import tqdm as notebook_tqdm\n"
+                ]
+            }],
+            "source": [
+                "import sys\n",
+                "\n",
+                "import jax\n",
+                "import jax.numpy as jnp\n",
+                "import numpyro.distributions as dist\n",
+                "import matplotlib.pyplot as plt\n",
+                "\n",
+                "\n",
+                "from berrylib.constants import Y_I, Y_I2, N_I, N_I2\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 160,
+            "metadata": {},
+            "outputs": [{
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "0\n",
+                        "10000\n",
+                        "20000\n",
+                        "30000\n",
+                        "40000\n",
+                        "50000\n",
+                        "60000\n",
+                        "70000\n",
+                        "80000\n",
+                        "90000\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "0"
+                        ]
+                    },
+                    "execution_count": 160,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "import numpy as np\n",
+                "import berrylib.fast_inla\n",
+                "import importlib\n",
+                "from functools import partial\n",
+                "\n",
+                "importlib.reload(berrylib.fast_inla)\n",
+                "from berrylib.fast_inla import FastINLA, jax_opt\n",
+                "\n",
+                "# assert jax.config.read(\"jax_enable_x64\")\n",
+                "\n",
+                "fi = FastINLA(n_arms=2)\n",
+                "# sigma2 = jnp.array(1e5)\n",
+                "# y = jnp.array([0, 0, 30, 30])[jnp.newaxis]\n",
+                "# n = jnp.array([30, 30, 30, 30])[jnp.newaxis]\n",
+                "# # fi.jax_inference(y, n)\n",
+                "\n",
+                "\n",
+                "def jax_faster_inv(D, S):\n",
+                "    \"\"\"Compute the inverse of a diagonal matrix D plus a shift S.\n",
+                "\n",
+                "    This function uses \"Sherman-Morrison\" formula:\n",
+                "    https://en.wikipedia.org/wiki/Sherman–Morrison_formula\n",
+                "    \"\"\"\n",
+                "    D_inverse = 1.0 / D\n",
+                "    multiplier = -S / (1 + S * D_inverse.sum())\n",
+                "    M = multiplier * jnp.outer(D_inverse, D_inverse)\n",
+                "    M = M + jnp.diag(D_inverse)\n",
+                "    return M\n",
+                "\n",
+                "\n",
+                "# @jax.jit\n",
+                "def jax_opt(y, neg_precQ, fast_loop=True):\n",
+                "    # y = jnp.array([29.65146991, 27.51985572])\n",
+                "    n = jnp.array([35, 35])\n",
+                "    # neg_precQ = jnp.array([[-28764.0366170816, 28764.031617082037], [28764.031617082037, -28764.0366170816]])\n",
+                "    logit_p1 = -0.8472978603872036\n",
+                "    mu_0 = -1.34\n",
+                "    tol = 0.001\n",
+                "\n",
+                "    def step(args):\n",
+                "        i, theta_max, hess_inv, go = args\n",
+                "        theta_m0 = theta_max - mu_0\n",
+                "        exp_theta_adj = jnp.exp(theta_max + logit_p1)\n",
+                "        nCeta = jnp.log(n) - jnp.log1p(exp_theta_adj) + (theta_max + logit_p1)\n",
+                "        diag = jnp.exp(nCeta - jnp.log1p(exp_theta_adj))\n",
+                "        nCeta = jnp.exp(nCeta)\n",
+                "\n",
+                "        grad = neg_precQ @ theta_m0 + y - nCeta\n",
+                "\n",
+                "        shift = neg_precQ[..., 0, 1]\n",
+                "        prec_d = jnp.diag(neg_precQ) - shift\n",
+                "        diag = prec_d - diag\n",
+                "\n",
+                "        # Apply the regularization suggested in: https://arxiv.org/abs/2112.02089\n",
+                "        H = 10\n",
+                "        reg = jnp.sqrt(H * jnp.linalg.norm(grad))\n",
+                "        diag += reg\n",
+                "\n",
+                "        hess_inv = jax_faster_inv(diag, shift)\n",
+                "        step = -hess_inv.dot(grad)\n",
+                "\n",
+                "        probit_step = 1 / (1 + jnp.exp(-theta_max))\n",
+                "        probit_step = probit_step * (1 - probit_step) * step\n",
+                "        go = jnp.max(jnp.abs(probit_step)) > tol\n",
+                "        # go = jnp.sum(step**2) > tol**2\n",
+                "        return i + 1, theta_max + step, hess_inv, go\n",
+                "\n",
+                "    n_arms = y.shape[0]\n",
+                "    theta_max0 = jnp.zeros(n_arms)\n",
+                "    init_args = (0, theta_max0, jnp.zeros((n_arms, n_arms)),  True)\n",
+                "    max_iter = 1000\n",
+                "\n",
+                "    if fast_loop:\n",
+                "        out = jax.lax.while_loop( lambda args: ((args[0] < max_iter) & args[-1]), step, init_args)\n",
+                "    else:\n",
+                "        args = init_args\n",
+                "        step = jax.jit(step)\n",
+                "        converged = False\n",
+                "        for i in range(max_iter):\n",
+                "            args = step(args)\n",
+                "            out = args\n",
+                "            if not args[-1]:\n",
+                "                converged = True\n",
+                "                break\n",
+                "    i, theta_max, hess_inv, go = out\n",
+                "    return theta_max, hess_inv\n",
+                "\n",
+                "\n",
+                "# def run(y, i):\n",
+                "#     # cov = jnp.full((fi.n_arms, fi.n_arms), fi.mu_sig_sq)\n",
+                "#     # cov = cov + jnp.diag(jnp.full(fi.n_arms, sigma2))\n",
+                "#     # # shift, prec_d = berrylib.fast_inla.jax_faster_inv(jnp.repeat(sigma2, arms), 100)\n",
+                "#     # # neg_precQ = -(jnp.diag(prec_d) + shift)\n",
+                "#     # neg_precQ = jnp.linalg.inv(cov)\n",
+                "#     n = np.array([[35, 35]])\n",
+                "\n",
+                "#     with open(\"out.txt\", \"a\") as f:\n",
+                "#         def p(x):\n",
+                "#             f.write(str(x) + \"\\n\")\n",
+                "#         p(y)\n",
+                "#         f.flush()\n",
+                "#     opt = jax_opt\n",
+                "#     theta_max, hess_inv = opt(\n",
+                "#     y[0],\n",
+                "#     n[0],\n",
+                "#     # fi.cov,\n",
+                "#     fi.neg_precQ[i],\n",
+                "#     # None,\n",
+                "#     fi.logit_p1,\n",
+                "#     fi.mu_0,\n",
+                "#     fi.tol,\n",
+                "#     )\n",
+                "#     if np.isnan(theta_max).any():\n",
+                "#         assert False, (y)\n",
+                "#     return theta_max\n",
+                "\n",
+                "trials = 100_000\n",
+                "\n",
+                "acc = 0\n",
+                "def test(y, j, fn=jax_opt):\n",
+                "    global acc\n",
+                "    if not fn(y, fi.neg_precQ[j]):\n",
+                "        acc +=1 #(i, y, j)\n",
+                "\n",
+                "# y = jnp.array([ 7.28087852, 19.92078862])\n",
+                "# j = 0\n",
+                "# test(y, j, fn=partial(jax_opt, fast_loop=False))\n",
+                "\n",
+                "fn = jax.jit(jax_opt)\n",
+                "acc = 0\n",
+                "for i in range(trials):\n",
+                "    arms = 2\n",
+                "    y = np.random.uniform(0, 35, size=(arms))\n",
+                "    if i % (trials // 10) == 0:\n",
+                "        print(i)\n",
+                "    for j in range(15):\n",
+                "        test(y, j, fn=fn)\n",
+                "# # %timeit run()\n",
+                "# _, exc, _, _ = fi.jax_inference(Y_I2, N_I2)\n",
+                "# exc[-1]\n",
+                "# ret = fi.jax_inference(Y_I2, N_I2)\n",
+                "# sigma2_post, exceedances, theta_max, theta_sigma=ret\n",
+                "# for r in ret:\n",
+                "# print(r.dtype)\n",
+                "# theta_max = jnp.array([0.1, 0.1, 0.1, 0.1])\n",
+                "# theta_m0 = theta_max - fi.mu_0\n",
+                "# theta_adj = theta_max + fi.logit_p1\n",
+                "# exp_theta_adj = jnp.exp(theta_adj)\n",
+                "# y = Y_I2\n",
+                "# n = N_I2\n",
+                "\n",
+                "# jax_opt()\n",
+                "acc\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 164,
+            "metadata": {},
+            "outputs": [{
+                "data": {
+                    "text/plain": [
+                        "(array([[ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                        "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                        "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
+                        "        ...,\n",
+                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+                        "        [ 1.,  1.,  1., ...,  1.,  1.,  1.]]),\n",
+                        " array([[        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                        "           8.5175151 ,   8.87252596],\n",
+                        "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                        "           8.5175151 ,   8.87252596],\n",
+                        "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
+                        "           8.5175151 ,   8.87252596],\n",
+                        "        ...,\n",
+                        "        [-15.78124253, -15.25253092, -14.32642149, ...,   1.32578601,\n",
+                        "           2.18722541,   2.42099027],\n",
+                        "        [-15.81360094, -15.28283245, -14.3575988 , ...,  -2.60645969,\n",
+                        "          -2.60283052,  -2.60188043],\n",
+                        "        [-15.83460559, -15.30497092, -14.383241  , ...,  -3.23427153,\n",
+                        "          -3.23251662,  -3.23205077]]))"
+                    ]
+                },
+                "execution_count": 164,
+                "metadata": {},
+                "output_type": "execute_result"
+            }],
+            "source": [
+                "with open(\"/home/const/kevlar/out.txt\") as f:\n",
+                "    arr = np.array(eval(f.read()))\n",
+                "arr.shape\n",
+                "np.linalg.slogdet(arr)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 18,
+            "metadata": {},
+            "outputs": [{
+                "name": "stdout",
+                "output_type": "stream",
+                "text": [
+                    "0.0010487821918949499\n",
+                    "[0.00074172 0.00074148]\n"
+                ]
+            }],
+            "source": [
+                "# with jit:\n",
+                "x = np.array([2.3373992443084717, 2.337362289428711])\n",
+                "y = np.array([2.3381409645080566, 2.338103771209717])\n",
+                "\n",
+                "def \n",
+                "\n",
+                "# without jit:\n",
+                "# [2.3373985290527344, 2.3373618125915527]\n",
+                "print(np.linalg.norm(x - y))\n",
+                "print(np.abs(x-y))\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 61,
+            "metadata": {},
+            "outputs": [{
+                "name": "stdout",
+                "output_type": "stream",
+                "text": [
+                    "[[-6.37561     0.02439026  0.02439024  0.02439024]\n",
+                    " [ 0.02439026 -6.37561     0.02439026  0.02439025]\n",
+                    " [ 0.02439025  0.02439026 -6.37561     0.02439024]\n",
+                    " [ 0.02439025  0.02439025  0.02439024 -6.37561   ]]\n",
+                    "[[-0.1568547  -0.00060468 -0.00060468 -0.00060468]\n",
+                    " [-0.00060468 -0.15685467 -0.00060468 -0.00060468]\n",
+                    " [-0.00060468 -0.00060468 -0.15685469 -0.00060468]\n",
+                    " [-0.00060468 -0.00060468 -0.00060468 -0.15685469]]\n"
+                ]
+            }],
+            "source": [
+                "def logit(x):\n",
+                "    return jnp.log(x) - jnp.log(1 - x)\n",
+                "\n",
+                "\n",
+                "def get_log_berry_likelihood(y, n):\n",
+                "    def log_berry_likelihood(theta, sigma_sq):\n",
+                "        ll = 0.0\n",
+                "        ll += dist.InverseGamma(0.0005, 0.000005).log_prob(sigma_sq)\n",
+                "        cov = jnp.full((4, 4), 100) + jnp.diag(jnp.repeat(sigma_sq, 4))\n",
+                "        ll += (\n",
+                "            dist.MultivariateNormal(-1.34, covariance_matrix=cov).log_prob(theta).sum()\n",
+                "        )\n",
+                "        ll += dist.BinomialLogits(logit(0.3) + theta, total_count=n).log_prob(y).sum()\n",
+                "        return ll\n",
+                "\n",
+                "    return log_berry_likelihood\n",
+                "\n",
+                "\n",
+                "ll = get_log_berry_likelihood(y, n)\n",
+                "theta = jnp.array([0.0, 0, 0, 0])\n",
+                "sigma_sq = 1e1\n",
+                "ll(theta, sigma_sq)\n",
+                "grad = jax.grad(ll, 0)\n",
+                "hess = jax.jacobian(grad)\n",
+                "h = hess(theta, sigma_sq)\n",
+                "print(h)\n",
+                "print(jnp.linalg.inv(h))\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def mcmc_berry_model(y, n):\n",
+                "    # y, n = data\n",
+                "    mu = numpyro.sample(\"mu\", dist.Normal(-1.34, 10))\n",
+                "    sigma2 = numpyro.sample(\"sigma2\", dist.InverseGamma(0.0005, 0.000005))\n",
+                "    with numpyro.plate(\"j\", 4):\n",
+                "        theta = numpyro.sample(\n",
+                "            \"theta\",\n",
+                "            dist.Normal(mu, jax.numpy.sqrt(sigma2)),\n",
+                "        )\n",
+                "        numpyro.sample(\n",
+                "            \"y\",\n",
+                "            dist.BinomialLogits(theta + 0, total_count=n),\n",
+                "            obs=y,\n",
+                "        )\n"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Stochastic Variational Inference"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                "name": "stderr",
+                "output_type": "stream",
+                "text": [
+                    "100%|██████████| 3000/3000 [00:02<00:00, 1104.55it/s, init loss: 78.8034, avg. loss [2851-3000]: 19.7578]\n"
+                ]
+            }],
+            "source": [
+                "import numpyro\n",
+                "from functools import partial\n",
+                "from numpyro.infer import Predictive, SVI, Trace_ELBO, init_to_uniform\n",
+                "from numpyro.contrib.einstein import RBFKernel, SteinVI\n",
+                "from numpyro.infer.autoguide import (\n",
+                "    AutoLaplaceApproximation,\n",
+                "    AutoDelta,\n",
+                "    AutoMultivariateNormal,\n",
+                "    AutoBNAFNormal,\n",
+                ")\n",
+                "\n",
+                "data = Y_I2[-1], N_I2[-1]\n",
+                "y, n = data\n",
+                "model = mcmc_berry_model\n",
+                "optimizer = numpyro.optim.Adam(step_size=0.005)\n",
+                "# guide = AutoLaplaceApproximation(model)\n",
+                "guide = AutoBNAFNormal(model)\n",
+                "# guide = AutoMultivariateNormal(model)\n",
+                "# guide = AutoDelta(model, init_loc_fn=partial(init_to_uniform, radius=0.1))\n",
+                "svi = SVI(model, guide, optimizer, loss=Trace_ELBO())\n",
+                "svi_result = svi.run(jax.random.PRNGKey(0), 3_000, y, n)\n",
+                "params = svi_result.params\n",
+                "predictive = Predictive(guide, params=params, num_samples=100000)\n",
+                "samples = predictive(jax.random.PRNGKey(1), data)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "data": {
+                        "text/plain": [
+                            "[<matplotlib.lines.Line2D at 0x14dc2b910>]"
+                        ]
+                    },
+                    "execution_count": 112,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                },
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAtg0lEQVR4nO3dd3wUZf4H8M83jYRQQwIiAUIVUYoYmiDSRAR7O+uBxx131tP7WSge6N2p6Hm2O1E5y6GiooiHJ0gVBASB0DuEahBSIEAghLTv74+d3WwvyW52J/m8X6+8sjM7O/udnd3vPPPM8zwjqgoiIjKfqHAHQERElcMETkRkUkzgREQmxQRORGRSTOBERCYVU51vlpycrGlpadX5lkREprd+/fo8VU1xnl+tCTwtLQ0ZGRnV+ZZERKYnIofczWcVChGRSfmVwEXkcRHZLiLbROQzEYkXkTYiskZEMkVkpojEhTpYIiKq4DOBi0gLAI8CSFfVSwFEA7gTwEsAXlPV9gDyAYwJZaBEROTI3yqUGAAJIhIDoC6AowAGA5hlPD8dwE1Bj46IiDzymcBV9QiAVwAchiVxnwKwHsBJVS01FssC0MLd60VkrIhkiEhGbm5ucKImIiK/qlAaA7gRQBsAFwJIBDDc3zdQ1Wmqmq6q6SkpLq1giIiokvypQhkK4ICq5qpqCYDZAPoBaGRUqQBAKoAjIYqRiIjc8CeBHwbQR0TqiogAGAJgB4ClAG4zlhkFYE5oQgRmb8jCjDVum0ESEdVa/tSBr4HlYuUGAFuN10wD8DSAP4lIJoAmAN4PVZDfbP4FM9f9HKrVExGZkl89MVV1MoDJTrP3A+gV9IjckOp4EyIikzFNT0zeOIiIyJEpEriIQMEMTkRkzxwJHCyBExE5M0cCZyU4EZELUyRwgCVwIiJnJkngwhpwIiInpkjgIoCyCE5E5MAcCTzcARARRSBzJHBmcCIiF6ZI4AAvYhIROTNFAhewIw8RkTNzJHBhCZyIyJlpEjgRETkyRQIHwAoUIiInpkjgAmE7cCIiJ6ZI4BCWwImInJkigbMKnIjIlSkSOAAWwYmInJgigVtu6EBERPbMkcDBwayIiJyZI4HzIiYRkQtzJPBwB0BEFIFMkcABdqUnInLmM4GLyEUissnu77SIPCYiSSKySET2Gv8bhypI3pWeiMiVzwSuqrtVtbuqdgdwOYBCAF8DGAdgiap2ALDEmA4J3pWeiMhVoFUoQwDsU9VDAG4EMN2YPx3ATUGMyxErwYmIXASawO8E8JnxuJmqHjUeHwPQzN0LRGSsiGSISEZubm4lw2QJnIjImd8JXETiANwA4Evn59TSSNttilXVaaqarqrpKSkplQpSWAQnInIRSAn8WgAbVDXbmM4WkeYAYPzPCXZwVrwrPRGRq0AS+F2oqD4BgG8AjDIejwIwJ1hBOWP5m4jIlV8JXEQSAVwNYLbd7CkArhaRvQCGGtMh88upIoz+cC1L4kREhhh/FlLVswCaOM07DkurlJCz3lJt2e5clJQp4mJYJiciMkVPTF7EJCJyZY4Ebpe/2SOTiMjCdAmciIgsTJHA7fEaJhGRhUkSOIvgRETOTJHAHerAWQInIgJglgRu95gXMYmILEyRwO2xBE5EZGGKBO7YjJCIiACzJHC7ShR2pScisjBHAmcJnIjIhSkSuD0WwImILEyRwB1agTOBExEBMEsCt6tDYTNCIiILUyRwe2eLy8IdAhFRRDBdAu835ftwh0BEFBFMkcA5GiERkStzJHAOZkVE5MIcCZz5m4jIhTkSeLgDICKKQKZI4ERE5MoUCdy5CmXulqPhCYSIKIL4lcBFpJGIzBKRXSKyU0T6ikiSiCwSkb3G/8ahClKcMvhL83eF6q2IiEzD3xL4GwDmq2onAN0A7AQwDsASVe0AYIkxHRKsAycicuUzgYtIQwADALwPAKparKonAdwIYLqx2HQAN4UmRCIicsefEngbALkAPhSRjSLynogkAmimqtbK6GMAmrl7sYiMFZEMEcnIzc2tXJQsghMRufAngccA6AHgbVW9DMBZOFWXqOUuC25HmVLVaaqarqrpKSkplQqSHXmIiFz5k8CzAGSp6hpjehYsCT1bRJoDgPE/JzQhsiMPEZE7PhO4qh4D8LOIXGTMGgJgB4BvAIwy5o0CMCckEbqLiUPKEhEhxs/lHgEwQ0TiAOwHcD8syf8LERkD4BCAO0ITIqvAiYjc8SuBq+omAOlunhoS1Gg8YBUKEZErc/TEZBmciMiFKRL48bPF4Q6BiCjimCKBf7b2cLhDICKKOKZI4ERE5MoUCXzy9Z3DHQIRUcQxRQJPiI12mOZFTSIikyTw7NPnHabZkYeIyCQJ/MTZ874XIiKqZUyRwKOiHKtMfj5xLkyREBFFDlMk8Gh2xSQicmGKBO5cAiciIrMkcJbAiYhcmCKBM38TEbkyRQJXthokInJhjgTOdt9ERC7MkcCZv4mIXJgigZeXM4MTETkzRwJn/iYicmGKBM46cCIiV+ZI4MzfREQuTJLAXTP44eOFKCgqCUM0RESRwRQJ3F0d+IC/L8Xt76yu/mCIiCKESRK4+zqUXccKqjkSIqLIEePPQiJyEEABgDIApaqaLiJJAGYCSANwEMAdqpofiiBZBU5E5CqQEvggVe2uqunG9DgAS1S1A4AlxnRIuKsDJyKq7apShXIjgOnG4+kAbqpyNB7c2bNVqFZNRGRa/iZwBbBQRNaLyFhjXjNVPWo8PgagmbsXishYEckQkYzc3NxKBdmtZSMsenxApV5LRFRT+VUHDqC/qh4RkaYAFonILvsnVVVFxG09h6pOAzANANLT0ytdF8IhZYmIHPlVAlfVI8b/HABfA+gFIFtEmgOA8T8nVEEa7xHK1RMRmY7PBC4iiSJS3/oYwDAA2wB8A2CUsdgoAHNCFSQAMH0TETnypwqlGYCvjRJwDIBPVXW+iKwD8IWIjAFwCMAdoQuTt1UjInLmM4Gr6n4A3dzMPw5gSCiCcof5m4jIkSl6YhIRkSvTJHD25SEicmSeBO5hfvsJ81DGOz4QUS1kngTuoQheWq6Yu/Wo2+eIiGoy8yRwL8+dLymrtjiIiCKFeRI4K8GJiByYKIF7ea76wiAiihimSeDxsdHhDoGIKKKYJoG3TKob7hCIiCKKaRI4ALRNTnT/BOtQiKgWMlUC//N1nd3OVyOD7zp2GnuzeZ9MIqodTJXAB3VqiuduuMTj88NfX4GrX1tejREREYWPqRI4AIy6Ii3cIRARRQTTJXB32ESciGqjGpHAv9qQhcPHC8MdBhFRtaoRCXzdwXzc8NbKcIdBRFStakQCB4CThSXhDoGIqFqZMoHHRvP2PEREpkzgdeP8uZUnEVHNZsoE/uUf+oY7BCKisDNlAu/YrH64QyAiCjtTJnAiIgoggYtItIhsFJFvjek2IrJGRDJFZKaIxIUuTFfPjLy4Ot+OiCjiBFIC/yOAnXbTLwF4TVXbA8gHMCaYgflyR8+W1fl2REQRx68ELiKpAEYCeM+YFgCDAcwyFpkO4KYQxOdRg/hYjOzavDrfkogoovhbAn8dwFMAyo3pJgBOqmqpMZ0FoIW7F4rIWBHJEJGM3NzcqsTq4tHBHYK6PiIiM/GZwEXkOgA5qrq+Mm+gqtNUNV1V01NSUiqzCo+i2J+HiGoxf3rE9ANwg4iMABAPoAGANwA0EpEYoxSeCuBI6MJ0z1KTQ0RUO/ksgavqeFVNVdU0AHcC+F5V7wGwFMBtxmKjAMwJWZQesARORLVZVdqBPw3gTyKSCUud+PvBCcl/USyBE1EtFtCgIqq6DMAy4/F+AL2CH5L/mL+JqDYzdU9MlsCJqDYzdQJn/iai2szkCZwZnIhqL1Mn8PgYU4dPRFQlps6ASYlx6Ne+icv8n0+4v8HxnuwCrMrMC3VYRETVwtQJXEQw47d98PCg9g7zn5y12e3yw15bjrvfW1MdoRERhZypE7jV8r2OY6xsOHQyPIEQEVWjGpHAne/QU1xW7mFJIqKao0Yk8D5tXevBiYhquhqRwEd2cR0XfMnO7DBEQkRUfWpEAk+Ii3a5U/2f/7stTNEQEVWPGpHAAaBnWhI+HlMxNEuDhNgwRkNEFHo1JoEDwJUdKm4YsetYAbYdORXGaIiIQqtGJXBn1/1zZbhDICIKmRqdwImIarIal8DTmtQNdwhERNWixiXw0nJ1mH5j8d4wRUJEFFo1LoGrY/7Ga4v34HxpGYpL2TuTiGqWGpfA3x+d7jKv86QF6P3C4jBEQ0QUOjUugXe6oIHDdGJcNMrKFfmFJWGKiIgoNGpcAnd2trgsrO+fmXMGJwuLwxoDEdVMNT6Bh9vQV3/AyDfZHp2Igq9GJvCVTw8KdwgOjpw8F+4QiKgG8pnARSReRNaKyGYR2S4izxnz24jIGhHJFJGZIhIX+nD9k9q4LhrEx4Q7DCKikPKnBH4ewGBV7QagO4DhItIHwEsAXlPV9gDyAYwJWZSVkBAXHe4QKIyOnDyHrHz390almu1A3tlaMw6SzwSuFmeMyVjjTwEMBjDLmD8dwE2hCLCynrvh0nCHQGHUb8r36P/S0nCHQWEw6JVltWYcJL/qwEUkWkQ2AcgBsAjAPgAnVbXUWCQLQAsPrx0rIhkikpGbm+tukZAYfukF1fZeRETh4FcCV9UyVe0OIBVALwCd/H0DVZ2mqumqmp6SkuL7BUE0/BL/kviuY6dRVBLe5oZERIEKqBWKqp4EsBRAXwCNRMR6pTAVwJHghlZ1T1zT0e38W6b+iJ9PWOpH888WY/jrK/D0V1uqM7Raq6ikDB+vPgh1HvOAiALmTyuUFBFpZDxOAHA1gJ2wJPLbjMVGAZgTohgrrX3T+m7nbzh8Ele+bKkfPVtsqQXKOJhfbXHVZi/P340/z9mOBduPhTsUItPzpwTeHMBSEdkCYB2ARar6LYCnAfxJRDIBNAHwfujCDD2WCKuHtVfqmfOssqKaT1WRfbooZOv32VhaVbcAuMzN/P2w1IfXOKVl5SgtV8THBq8pYlZ+IVIbm3Os8jPnS5EQG43oKKn6yoxV8IBJtcG/V+zHC/N2Ycn/XYV2KfWCvv4a2RPT3vpnhnp87sz5UrfzR3+4Dp3+PD+ocdz29uqgrq+6lJcrLp28ABNmbw3K+sTI4EzfVBUlZeX4Yt3PKC+P7G/Sir15AICs/ND0xq7xCbxJvTr445AObp97atZmiFgSSkFRRTJfmZkX9DhyCkJ3GhVKZUZJ+asNWUFZn1gL8ZH9u6MI996KA3jqqy2YtT4438tQsZ5oBuHc1a0an8AB4PGr3bdGWbwjx/a44HwpDuSddXh+yc7sSr3fD3tyUVLmeAMJs+arMqOEEyXB+QqG6otcnUrLymt9FVBBUQlyC86H7f2Pn7G896lzkT1MtBq//CD9fFzUigQOAEmJrkO1FJeVo9Qu0e7PPePw/HfbAm8psXrfcYz6YK3LrdzM+nsv19B8AdWkh7TyckX7id/hL9/uCHcoYTXw78vQ83neJMWXihJ4aDJ4rUngni7AXfX3ZbbHwahOyzVKBgeOn/WxpDkEvQRuu4gZlNVVO2uV0serD4U5kvA6fpZj3PvD+j0PxvV/d2pNAr/5Mrc9/R38sCfHYdo+yby3Yj8yDp4IdlgRr9w4QQnWF9DsFzEDPfCUlyvu/3AtfgzBdRWKfLYzTSbwqhk3vBM6N2/gdZmDeYW2HprO/jZ3J257x3dLEmvdaE2o6wWAUiODswRuEWidZkFRKZbuzsUDn6wPYVS1V6RXxYX6e15rEnhUlODjMb3w5l2X4cCLI9wuszIzz9ZDs6okwISnqg718ZHCWmUQFaQiuC2BR/gPzxPrD9KsB6CaIlQXBYPN+jVhHXgQNKlXBzd0uzDg5FodXl6wG+0nfofi0shK4sGuQrGem9SWBGjWAxUFibUGhVUo1e+HPTm4+98/4af9x12eO3G2GDt+OR209/rEuChWVBpZXcxtJfAgfQPXH7JcRzBrWqtsq5xILDRQ6Nmq3EK0/lp737G7erXCZ2sPe10m70wx8s4cx6HjrvXi1/9zJY6cPIdJ13VGSVk5fn9VuyrFE46EVlpWDhHx2kXe2tMtGFUoRSVl2JNtNNU0aRHcpGHXWJG+P2zNCEN0AK+1JfAXb+mC7i0b+bWsu5sSW+f95dsdePG7Xbb5Ve155et1qoqf9h8PSkeS9hO/wy1Tf/S6TEUzwiq/nW1dQA0ogUfQZeojJ88hbdxcLNud43W5T9ccxsC/R8ZdijYczsee7IJwh+FTSVk55mw6Uunfm60OnFUowfffh/phRJfA7tyz/lA+znoYQyX7dBEem7kJgGWHOTc7nLPpiG00vspasD0bd077CZ/8FFg75HYT5uHZb7a7zN+c5f3egcGuQjG7SDzwbDp8EgDwRcbPXpeb8PVWHHRzNhkOt0xdhWGvLa/066urSurtZfvwx883Ye7Wo1VaD7vSh8g1ft61x+qrDVm4ZPICt8/Zl4DyC0vw4Y8HHZ7/4+eb0P0vi7yu31eCsDZzDPSHWFau+M+qgz6Xc/c6wHsCP3O+FF9v9D0mhf22RfqpryeBxh3M7Xxh3k68NH+X7wV9sC9NZuYU4I53V3sslNR21qFg8yvZcSnUQy7U+gSeXK9OQMt/usZzvXlJWcXOWr4n1+dR+6PVBzF3i2UZ645WPxuheBsDYtex01X64uQWnEfauLlYuTevIoG7+aacLipBYXEpJszeisdnbsaWrJNe11tuF1O5m/iy8gvxXRVLOqEW6OcazJ/vtOX78fayfVVej32P4xfn7cLaAyewel/FhfrFO7Jx89QfI36kPzNgFUqIXdGuCabe0wNjB7St0noKikoCasf9py82YdKc7Xjo0w0O8/1tduZpFLYfM/Mw/PUVmOHlQOPO2fOltrvkbDxsuTvRf1Yd8FoC7/rsQvR98XscO2UppRQWe29BY39wcpcHb566Cg/M2OD6RATxJ39n5RfiVGGJsXzlkuDFf56Pl/0sbQfaVLHMR2J+5LON2Hj4JM65uU/s+NlbkDZubkDvV1XHz5z3GXOoVDbxni8tw7qDJ3gRM9REBCO6NMeEERdXaT09n1+MOZt/8Xv52RscbyFq/XrO33YMG4wEqqoupSD7H6u1tHrsVJHtzOB3H2UAsJTCAaDLswsw+B/LfMbzxJeb8fuP12N/7hm7dxBbSdlTFcqpcyVY6+cQA/albuuj/LPFtrbv1tHtIrnk509k/V9aimGv/wCgorQb6O/3XEkZpgahtO2Or2RY0dnK1Wdrvdez28s5XYRpy/dhn9MgcYE4XVSCy/+2GM/P3VnpdQSDt08s/2yxy7Wt5/63A7e/sxqbfj4JgHXgEa+opBwbjYtJgSovV1vpddzsrbhl6iocPXUOz8/dibYT5jmU4uwLdA/M2ABVxegP12LC11uRd+a8bT0xRp1HQVEp9uf6HljL+iMrKVOHAXisP/acINwWqswu+NyC87hk0nxc9tdFeHCGYzfzkvLQdmYqL1f87qMMh2oDv1/rZzOj7NOWg1EkduQp83FW4G7TikrKMHnONr/fo7i0HL1eWIIX5u3CrW+vCjDCCtYzmareQ7WgqMQlyX6x7mes2ud9jBp/Whtd9tdFLte2dh517CPCEngN8s4PjiWrfi9977JM3xe/x3srDwAAfjs9A6eLSlBSVo5DTmO1vL54L3YdszTHsv9deiox935hse1HYc9afx8bLRXjuUhFwjrro3rEH/Yl8GW7c2zrXLzTsflbaZn3BLN0V47tDKMyCopKsWhHNsZ+nOEwf+XePMxc57nqaV/uGaT/LcAhVIOUv+3Hl//FrlnrkZPnXIYsVVW8OG+nx2sSZR4+38LiUvR+YbFtv9gXHGZvOILpAYzAeN6uQ5q3C6RvLc2sliEkehhJNrfgvO1zeeqrLXiomqrsWAKvRp+P7YOOzYJ//zqrKd851m0ePeW9dLtkVw66PrsQI99c4XIR9Y0lFeOO258aH8g74zImOWApGXb7y0KX+dZqjCgRW85ZsD0bp4scf3xnzpdi4tdbPd6Ozt6+3DPYdqSimaL9AcZ60LFnbWteWq44c77Udvo5a30W0sbNtSWC+/+zDsNfX+Hw2n8v349Vbkb8Ky9XfLz6IP7yvx341/eWz8N6ILHvwPTMf7fi3vfX4OmvPN86zv4GHyVl5fj4p0NoO76iPnjl3jyH+mFVtVWhnCwssSXEbUdO4ZQx/cOeXFuVUUlZucfqo+GvL3d5vP7QCfSb8j1mG3dLspb2S8sV7y7fjxvfcmzjbz2me+rtm5lzxnbmAFQMowA4JmRnpwpL8KVTE0b713qrsvn7gt34euMRl/nrD+U7HEDsyyPHThVh2vL9HtfpjrWAcu0by3HDvyo+l3w3hRl71usAZeWKzJzKt1sP1XlYre2J6c4rt3fDmv3H0adtE7x7XzoGvbIs3CE5sPVi9OAfC3fbHi/dnYulu3M9LvvrD9baHr++eI+tY9IDMzbguq7Nbc+N+2qLw+v+8+MBzFhzGM0axLtdr6pi6e4cNGsQj5FvrgQAzH7wCrROquu25YnVj5l5iBJLnXtRSRl6v7AEAPD7q9pi4XZL4jxy8hw6Nqtve82Kvbm4skMKDh8vxPPzLHWkB6eMdFhv2wnzHKZbN0lEn7ZNAFiSamFxKerGxeCTnyoOjDPXHUa/9skON6HOzCnA2gMVdf2qwJ//a6lS2HA4Hz1aNbYlUqs24+fhhycH2qZPnytFg4QYXPfPlWibnIjHr+6IRz7biFsua4HZRhK7q1crvHDzpS6fzz67arDTRaVQVdxq3Gd1g1PVnTVhqlbEBlgOzmWq6P3CEvzn/p4Y/eE6XN66se11zneRKlfFycJi/LT/hMckrKp4/ItN+H5XDrq3bIQOxv6xrwbzdUnjyVlbMPCipkipb2kRtmx3DkZ/uA6Tr++MIZ2auSz/6Ocb7T6XMzh0/CxaN0lEUUmZ274O9vLOWKpRJnzt3z1erY0Fnvuf5QYeCx8f4PAd9MS5xL3r6Gm/Ow4Gggnczm2Xp+K2y1MBADGhGoE9hL4M4P6Ay/dUJPfX7UrqO4+edqi/sy+R/fXbHXjfqNZ5ddEel3XO3pCFO6f95DL/lqmr0CY50esX+J731tgev2a37nd/qChp/WPhbrx7X7pt+r731+KTMb1x7/sVr738r4uQ2jjB4/s88tlG/Lpva9t050kLMO/RKx2WsZbC9/ztWuw4ehotGydg6KueO53M3pCFW6a6r+e1v2FIYUkpNhmn7/vzziLHuGg7264E+tnaw7i3Tyvb9MLtx7DFTWcr+8/Z2qRUIMjMKXA407ll6ir84/ZuuPXyVMs1DWP+6A/XAQC2GmdIP+7Lc7kmcPxsMYa+arkYO8ruM7OnWlGlU2wcANYfyndbYi8uLUdOQZHDgdFqb04BUurXwcnC4orYsk6hdxvLwTYr/xwO5p1FWnIiztlV532RkYUvMrLwzr2XI7+wGJ+v8+8iq/2Z7NiPMrBwRzY2TxqGhnVjvb7OvhDxxuK9OGZ3bWjbkVO4tEVDt6/7x6I9uLNXK7fPVYXPBC4iLQF8BKAZLGcC01T1DRFJAjATQBqAgwDuUNX8oEcYJi2TKr5kN1/Wwu1pXm1jTd6efJHh+QByIO+syz1HPfH0I1ywPRt9X1ziMM8+eQOWpOPrbjEfOdXlvrfS/el4x2e+8xUqADiU3r1ZfyjfoSQbF+O+BtN65gIAYz92P474mgOuLX/mbj3qtu/BD3tycevlqQ79FKysVWfOnc4A2JI3AI/13+WqtjOr/248gk4XNPB40XLC11sxa30W3r3vcpfn/vV9Jk6cLcYHdt+x2RuPOBzcBr6yDG/c2d120LG3al8eLnYa7z8rvxAfrDyI1k1cDxj2Fu6wnOF9tSEL/Tsk2xK0u+osS4ODUkyes92lwHTdP1fi4JSReHXhbpezotyC88gpKELT+u7PXCtLfLVTFZHmAJqr6gYRqQ9gPYCbAIwGcEJVp4jIOACNVfVpb+tKT0/XjIwMb4tElFOFJZAoIC46Cvtyz+BgXqFLu22iQLz2q254fOZmAEDblES/WggFw8u3dsVTTtVhwdC9ZSPbtQpvEuOig3Ih3Bt/Bqjzx4qnBmHVvjx0bFYfN3s4s/KkRaMEt2MnAcDSJwaiTXJipWISkfWqmu4yP9COBiIyB8C/jL+BqnrUSPLLVPUib681WwJ352RhMRrVjcPfF+zCW0tD006Xaq6HBrXj96aWWj1+MJo39Fy9542nBB5QKxQRSQNwGYA1AJqpqvV87RgsVSzuXjNWRDJEJCM31/NFNbNoVNf17vb2Jl/f2evzY/q3CWY4ZDJM3rVXfEx00NfpdwIXkXoAvgLwmKo6NMJVSzHebVFeVaeparqqpqekpFQp2EgydoD78b+jRPDEsI4eX2e9SOqPd+7t4TLvfw/39/v1RBQ5GiR4v0BaGX4lcBGJhSV5z1DV2cbsbKPqxFpP7n0w4hqmoYedESVA+6aWNuQX2TU3srY5bpdSD5snDcO6iUMx47e9cU9v91em7+vTGsMvbY6Jdl38r+7cDF1SK65y/zR+SJW3w52eaY3dzp//2JWY9Ye+Xm8A4e3gRVSbefvdVJbPBC6WPqDvA9ipqq/aPfUNgFHG41EA5gQ9ugi3buJQrJs4FKvHD7aVrO27zLZuUhcHp4zEwSkj8eHonhh6cVPERgsa1o1FSv066Nc+Gc/f3MW2fKcLKhL+X2+ytAX+3YC2ODhlJDZPHoap9ziWyC9o6P8V7Zdu7YJBF/l3BvTW3Y7v07xhPBY+PgCdLmiA9LQkXHOJY23ZR7/phW8f6Y95j16JKztUvEd6a9cDgacD303dL/Qa079/7VL959XHY3ph4eMDAnpNbbRu4lCPrWHIVVKi9yrU6ubPnusH4D4Ag0Vkk/E3AsAUAFeLyF4AQ43pWiWlfh2k1K+D5g0TcMmFliZMliZLrkfaAR1T8N6onm7HRLi1hyX5e0tSDRNiERvte3c9eY3jdeROF9THuolD8auerTDt1+l4ZHB7vHRrFw+vtmiQEIvebZIw5ZYu2PfCCKweP8Sh84L9de/f9GuDKzsk49IWDdH5wgYotWt69f7onrbHK54ahA/v74nNk4fhm4f74anhjnHe0bOl15iuaNfE6/MA0NmuGdmVHVLQLsW1N+3aiUPwzcP9bNMjuzZ36GzjzYeje+JZH9c41k4YghVPDXL7XNdU922EAcsB9ss/9PW6but3zJMZv+3tMP3W3T1wcfMG2P7cNTjw4gi3r0mpXwdXdXR/YPc01PLaCY5nfvf3S/O4zcHw+dg+ACytwUJh86RhLvPu7dMKv7/KcYTSLi0aYsOfr/a5vktbuO6nOiE6SPpcq6quVFVR1a6q2t34m6eqx1V1iKp2UNWhqurfkHQ11Ogr0vDfh/o5lED9bd8z5dYuWP/MULRMqouWSQkYf22nSsWQXC8ODw1qb5vumdYY8x8bYOvhFhsdhf8bdhF+1dN7h4IoEcz8fV/c2auV29M+awKfek8PTLq+s8NBydrOOb11Y4fSdsukuhh0UVMAQNfURhjWueJGGq2S6uKKdsn48P6KhL/12WG4ol0TLHtiIA5OGYnEOp67LCTEWi4OzX20P1aPH4zFf7KUvKOjBPf1qeiA8szIi9G0fjy6pjayve6tu3ugdZNEW8etVeMG45pLmuHbRyquNXz7SH/c26cVruqYgtH9Ki5Ct0qqi11/HY5/3X2ZbV7TBvEOfQjsffq7PrbH13e7EB2a1sPEERfjfw/3x696tkLPtCSXA1u9OjH44UnLZzDXrsORfUJeM2EItj13Dfq1T3bocj6ya3N898crkVgnBiKCF+zO9n6V3hILHrN8TvZ7uGn9iqQdF215Ji4mCrfbXbtp6tQLd/L1lzhs85d/6OvQaWvSdZ2x74UROPDiCIeDrNVFzeo7vC9gOTOwSm/dGG2TE/HmXd1dzg6dzwatXr6tK964s7vDvLYpiVg3cSjuSHe8DtWwbqzts7Dq3z4Z4691HKG0ZZKlBcnSJwa6fU+rbx+5EgenjMQ3D/dD47qxuLVHKmY/eIXX11QWe2IGiYjYvrSBDjwWGx2FJkZpZ8VTg30u/9P4IX6d9v7n/l4BxTGqb2s0SIj1ue6JIy9GaXm5LSHbKzW6UMdE+/chtE1OxPfGD8J+ffXjYx0SnlW31IZ4ZHAHS2m/TFG3TjROnSvB6n3HISIuzbQmXd8Zd/VqhdSkBDSIrzigfPmHvg49Ntc/czW2/XIKFzZKcOjtCQCXtmiIv7WoSH7P3XAJJn+zHfXjYxAfG43rul6Ihz/dCF/q2R2E/nnXZW6XeXBge7w8f7fDvNZNKtoOrzFKvyKC2GhBSZmiXp0Y2wHuwIsjPY7XfXfvVrYu5C/d1tU23zrw2dR7emBEl+bILTiP7NNFtqGJf3hyIJo3TMD4ERfj+BlL71F3zSF/HDcYMVGCZg3i8fGYXsg+fd52PchqzsP9UFRShp1HC7D+UD5emr8Lv+rZEtkFRQ69buvHV3xWMdFRtu8IADz0acX63r0vHYXFpfjl5DmH3rL92iejRaMEPD93p63H6yu3d0NK/Tr409UXuXQ669C0HpIS43DC6AQ20Pgu1o2Lto3wae0V2iY5EVueHYZDeYW4/l+WTlebJw1zGWOoa2ojbHRTug8mJvAQsJ56tk2pXKN9XzzVffdrn+ww7a3Ueu2lFyA6SvDsDZdgyc5sPP3VVtzcI9Wv8RpaJtXFe6N6un2uZ1oS7khPxSODOwCwlFYO5LkbwyXwuz9vmnQ14mOjER/r2BwruV4dt9UlgOXg2NlN1UPPtCSH6YZ1Y10+v0/G9MbpItfBjqzjh3jrQvG/h/sjOkow4k3LoFvW5N2nbZLPMW28sR+Dxnq241y1Num6zmhSz/+62i6pDTF/+zE0N75X1qrBimGFLTspKTHOVgdsbRL30KCK1lgtGlUcEOvHx6J+vOv1jtjoKMRGR6FXmyT0apOE3w9oCxHLZ/nAVe3Q/S+L8Ojg9n5VF1rVjYtx6WUaa5xRNUyIRU7BeXw8ppdtTBirxLhorDYOiFHGb+HRzzZiZNfmtu+Y9TP++sErHH4bDeJjkRBXEaO1C35115EzgYfA5a0bY8Zve6NXmyTfCwfJ0icG4sJGlh/g4E5NkezjB/z2vRXdme9Ib4mrOjYN6KKoJ7HRUXj5tm626TbJiW57n/k5rLYDX23wg61/h2S389s3rYeOzephkl19eItGCQ511F2c6rs3T7aUxD4f672e25m3jnadLmiAHUdPu4zb85sA+xo8cFU7DLwoBZdc6BjzK7d3w2uL96CJm6TUzihZ+zOwkzdRRuwilv3rXFfv6aI3ACx/sqLe3XkI4hjjAPDufZfj83U/o397131ZLz7G4azMWuq3317rx9+uaT2X61fOY7qsf6b6LwgzgYeIc2kuVGaO7YO8M8UOSfKD0e5Lx56ISFCSd20RHxuNhY9f5TDvx3Geq766pTYMqAnZrD/0hcJyE+OHBrb3uNwnv+2NPdkFtiToj6eGX4QUp4uTUVHikrwBywHM00FsRJfm+PaR/j4vrAbKPkm+ekc3h9ESnbWyG+PkkgsbOFTrxBpVeG1T6rncbct6QbHTBY6xD+yYgim3dMGN3VvY5lnHeYl1c1PY+NhorJkwBEXGkLNNAry/bjAwgZtc77a+W2dQ+GQ+f23Ad2NJN6p3vn6wn9flkhLjbEPj+utBLweEQHkaeS9Ybunhf6e3qCjBk9d0wjs/7EdZuXqtgmmcGIfPx/ZxOfiIiMuIgda7F3m6puNpWOXqwgagFBYVd+s237C9gYiJjgpJB47abNW4wVjmoSWINSn7Gg66T9smbuvonf3aaMUUqcNLswROYWH9PSQ4XZBsm5yI/X4OO0u104WNPA8INf3+XtidXWCrA6+qyddfggkjL47YggYTOIVFu5R6eGxoB5exYb55pD/OFPm+XRuRO40rUa3kTVSUoE5U8AehChYmcAoLEcFjQ13HTalXJ8ahvTQRecY6cCIik2ICJyIyKSZwIiKTYgInIjIpJnAiIpNiAiciMikmcCIik2ICJyIyKfE2XGXQ30wkF8ChSr48GUBeEMMJJ25L5Kkp2wFwWyJVVbaltaq63PuuWhN4VYhIhqoGdmfbCMVtiTw1ZTsAbkukCsW2sAqFiMikmMCJiEzKTAl8WrgDCCJuS+SpKdsBcFsiVdC3xTR14ERE5MhMJXAiIrLDBE5EZFKmSOAiMlxEdotIpoiMC3c8vojIQRHZKiKbRCTDmJckIotEZK/xv7ExX0TkTWPbtohIjzDH/oGI5IjINrt5AccuIqOM5feKyKgI2pZnReSIsW82icgIu+fGG9uyW0SusZsf1u+fiLQUkaUiskNEtovIH435ptsvXrbFjPslXkTWishmY1ueM+a3EZE1RlwzRSTOmF/HmM40nk/ztY0+qWpE/wGIBrAPQFsAcQA2A+gc7rh8xHwQQLLTvJcBjDMejwPwkvF4BIDvAAiAPgDWhDn2AQB6ANhW2dgBJAHYb/xvbDxuHCHb8iyAJ9ws29n4btUB0Mb4zkVHwvcPQHMAPYzH9QHsMeI13X7xsi1m3C8CoJ7xOBbAGuPz/gLAncb8dwA8YDx+EMA7xuM7Acz0to3+xGCGEngvAJmqul9ViwF8DuDGMMdUGTcCmG48ng7gJrv5H6nFTwAaiUjzMMQHAFDV5QBOOM0ONPZrACxS1ROqmg9gEYDhIQ/eiYdt8eRGAJ+r6nlVPQAgE5bvXti/f6p6VFU3GI8LAOwE0AIm3C9etsWTSN4vqqpnjMlY408BDAYwy5jvvF+s+2sWgCEiIvC8jT6ZIYG3APCz3XQWvO/wSKAAForIehEZa8xrpqpHjcfHADQzHpth+wKNPdK36WGjauEDa7UDTLItxmn3ZbCU9ky9X5y2BTDhfhGRaBHZBCAHlgPiPgAnVdV6Z277uGwxG8+fAtAEVdgWMyRwM+qvqj0AXAvgIREZYP+kWs6bTNl+08yxG94G0A5AdwBHAfwjrNEEQETqAfgKwGOqetr+ObPtFzfbYsr9oqplqtodQCospeZO1fn+ZkjgRwC0tJtONeZFLFU9YvzPAfA1LDs221o1YvzPMRY3w/YFGnvEbpOqZhs/unIA/0bFqWpEb4uIxMKS8Gao6mxjtin3i7ttMet+sVLVkwCWAugLS5VVjJu4bDEbzzcEcBxV2BYzJPB1ADoYV3bjYKn8/ybMMXkkIokiUt/6GMAwANtgidl61X8UgDnG428A/NpoOdAHwCm70+JIEWjsCwAME5HGxqnwMGNe2DldX7gZln0DWLblTqOlQBsAHQCsRQR8/4x60vcB7FTVV+2eMt1+8bQtJt0vKSLSyHicAOBqWOr0lwK4zVjMeb9Y99dtAL43zpw8baNv1XnVtrJ/sFxV3wNL/dLEcMfjI9a2sFxR3gxguzVeWOq6lgDYC2AxgCStuJL9lrFtWwGkhzn+z2A5hS2BpS5uTGViB/AbWC7GZAK4P4K25WMj1i3GD6e53fITjW3ZDeDaSPn+AegPS/XIFgCbjL8RZtwvXrbFjPulK4CNRszbAEwy5reFJQFnAvgSQB1jfrwxnWk839bXNvr6Y1d6IiKTMkMVChERucEETkRkUkzgREQmxQRORGRSTOBERCbFBE5EZFJM4EREJvX/HMn9p4Hc4wQAAAAASUVORK5CYII=",
+                        "text/plain": [
+                            "<Figure size 432x288 with 1 Axes>"
+                        ]
+                    },
+                    "metadata": {
+                        "needs_background": "light"
+                    },
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "plt.plot(svi_result.losses)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                "data": {
+                    "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlMAAAEvCAYAAABhSUTPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaRklEQVR4nO3df4xd9Znf8fcTA+s6JYnXsKJiTGcsYynxujulNslqtQppjJdg2USpd8HVSqyKoGxicLPpNlAqlLqRvEksW6sZJhQ3SZUVLYEW05FsiuMttNtoja5t7ro1lNQ7yeIhGWXWNlR1ahI73/4xY3MZz4/jOefec++575eENPfe4zmPco3y4fk+5/uNlBKSJEman/eVXYAkSVInM0xJkiTlYJiSJEnKwTAlSZKUg2FKkiQpB8OUJElSDleUdeNrrrkm9fb2lnV7SZKkzA4fPvzXKaVrp/ustDDV29vLoUOHyrq9JElSZhHxVzN95jKfJElSDoYpSZKkHAxTkiRJOZQ2MyVJkqrp5z//OaOjo5w9e7bsUi7bwoUL6enp4corr8z8ZwxTkiSpUKOjo1x99dX09vYSEWWXk1lKiZMnTzI6OkpfX1/mP+cynyRJKtTZs2dZsmRJRwUpgIhgyZIll91RM0xJkqTCdVqQumA+dRumJEmScjBMSZIk5WCYkiRJlXT+/Hm2bt3KypUrWbVqFSMjI025j0/zSZKkptr13e8X+vs+f+uKTNdt376dZcuWcezYMXbv3s3Q0BA7duwotBawMyVJUscZHxgsu4S2d+bMGfbs2cPWrVsB6Ovr4/jx4025l50pSZJUOQcOHODEiRP09/cDcOrUKdauXduUe9mZkiRJlVOv19m2bRv1ep16vc66devo7+/nzJkz3H333dx77708+eSThdzLMCVJUgdwae/ynD59mkWLFgFw7tw59u/fz4YNG3j22WfZtGkTu3fvZnh4uJB7GaYkSepQ4wODhqwZrFixgoMHDwKwa9cu1q9fT19fH6OjoyxduhSABQsWFHIvw5QkSW1mqD50yXu1sRr7Hrnb8JTR5s2bOXLkCMuXL+fo0aPs3LkTgJ6eHkZHRwH4xS9+Uci9HECXJKkNDdWH+Gz/Z2f8/HJC1YVrr31gS+665iPrVgZFWrx48cXOVKPPfOYzbNmyhb1797Jhw4ZC7mWYkiRJXeP9738/3/rWtwr9nS7zSZIk5WCYkiSpAhxGL49hSpIkKQfDlCRJFTK1O2W3qvkMU5IklWS6LRCK4rJf6ximJEkq0VB9aMZQNdtnah+GKUmS2lTvMy/P68/ZkWot95mSJKlN7Hvkbn742x+95P2h+hC9rS9HGRmmJElqM1k7UrWxGmuuW2MnqmSZlvki4raIeD0ijkfEQ9N8fkNEvBgRr0TE0Yi4vfhSJUlSbax28R/N7vz582zdupWVK1eyatUqRkZGmnKfOTtTEbEAeAy4FRgFahExnFJ6teGyfwE8nVL6ekR8BNgHdiQlSRLw4vZif98nHs502fbt21m2bBnHjh1j9+7dDA0NsWPHjmJrIdsy383A8ZTSCEBEPAXcATSGqQR8YPLnDwI/KrJISZK6xXyHzvVeZ86cYc+ePRw+fBiAvr4+9u7d25R7ZQlT1wMnGl6PAlOn474E7I+IB4D3A2sLqU6SJGkeDhw4wIkTJ+jv7wfg1KlTrF3bnHhS1NYIm4F/m1LqAW4H/iQiLvndEXFfRByKiEPj4+MF3VqSpM6XZz8pZ6guVa/X2bZtG/V6nXq9zrp16+jv72dkZIR77rmHTZs2FXavLGHqTWBpw+ueyfca3QM8DZBS+nNgIXDN1F+UUnoipbQ6pbT62muvnV/FkiRJczh9+jSLFi0C4Ny5c+zfv58NGzawbNkyvvGNbxR6ryxhqgbcGBF9EXEVcBcwPOWaN4BPAkTEh5kIU7aeJEnKqfeZl52jmocVK1Zw8OBBAHbt2sX69evp6+tryr3mDFMppXPAFuAF4DUmnto7FhHbImLj5GVfAO6NiL8A/j3weyml1JSKJUnqQB4N01qbN2/myJEjLF++nKNHj7Jz586m3SvTpp0ppX1MbHfQ+N6jDT+/CvxGsaVJklRNZYWq8YFBrn1gS+tvnHErgyItXrz4Ymeq0cmTJ3nkkUd45ZVX2L59Ow8/nL82d0CXJEldY8mSJTz++OOF/k4POpYkScrBMCVJUgdr3BLhcrZH8Dy/4himJElqIYfQq8cwJUmSlINhSpKkJrITVX2GKUmSpBwMU5IkSTkYpiRJKlHRR8V46HHrGaYkSZJyMExJklRBdqfg/PnzbN26lZUrV7Jq1SpGRkaach+Pk5EkqQna9Sm+MjbrLPp/i8/2fzbTddu3b2fZsmUcO3aM3bt3MzQ0xI4dOwqtBQxTkiSVrui5KcGZM2fYs2cPhw8fBqCvr4+9e/c25V6GKUmSVDkHDhzgxIkT9Pf3A3Dq1CnWrl3blHs5MyVJkiqnXq+zbds26vU69XqddevW0d/fz3PPPce9997LnXfeyf79+wu5l2FKkiRVzunTp1m0aBEA586dY//+/WzYsIFPf/rT7N69m8cff5zvfOc7hdzLMCVJkipnxYoVHDx4EIBdu3axfv16+vr6Ln7+5S9/mc997nOF3MswJUlSlyrjyb5W2bx5M0eOHGH58uUcPXqUnTt3ApBS4otf/CKf+tSnuOmmmwq5lwPokiSVoJue4Mu6lUGRFi9efLEz1WhgYIADBw7w9ttvc/z4ce6///7c9zJMSZLUZO2651Q3evDBB3nwwQcL/Z0u80mSJOVgZ0qSpC7WODd17QNbSqykc9mZkiSpompjNc/oawHDlCRJLdL7zMtdNXjeLQxTkiS1mIGqWgxTkiQVzKf3uothSpKkinNuqrkMU5IkSTkYpiRJEjCxTUKVjpg5f/48W7duZeXKlaxatYqRkZGm3Md9piRJUlMVHdCy7oe1fft2li1bxrFjx9i9ezdDQ0Ps2LGj0FrAMCVJkirozJkz7Nmzh8OHDwPQ19fH3r17m3Ivw5QkSQWZ7Sk+t0NorQMHDnDixAn6+/sBOHXqFGvXrm3KvZyZkiRJlVOv19m2bRv1ep16vc66devo7+/ntdde4/7772fTpk18/etfL+RehilJklQ5p0+fZtGiRQCcO3eO/fv3s2HDBj784Q/z+OOP8/TTT/O9732vkHsZpiRJUuWsWLGCgwcPArBr1y7Wr19PX18fAMPDw6xfv57bb7+9kHsZpiRJKoC7nreXzZs3c+TIEZYvX87Ro0fZuXPnxc82btzI888/z5NPPlnIvRxAlyRJTZV1K4MiLV68+GJnqtFLL73Es88+yzvvvFNYZ8owJUmSusYtt9zCLbfcUujvdJlPkqQuUBureUZfk9iZkiQpB2elZGdKkiQpB8OUJElN0vvMy+583gUMU5IkqXAppbJLmJf51G2YkiRJhVq4cCEnT57suECVUuLkyZMsXLjwsv6cA+iSJM1TlYfPxwcGgfntEdXT08Po6Cjj4+NFl9V0CxcupKen57L+jGFKkqQm67a5qSuvvPLi0S3dwGU+SZL0Hhe6UsrGMCVJUpdx885iGaYkSZJyMExJktRF7EoVzzAlSZKUQ6YwFRG3RcTrEXE8Ih6a4ZrfiYhXI+JYRPy7YsuUJElqT3NujRARC4DHgFuBUaAWEcMppVcbrrkReBj4jZTS6Yj4lWYVLElSJ+i27RC6WZbO1M3A8ZTSSErpZ8BTwB1TrrkXeCyldBogpfSTYsuUJEllcJuEuWUJU9cDJxpej06+12gFsCIivhcRByPitqIKlCRJamdF7YB+BXAjcAvQA/y3iFiVUnqr8aKIuA+4D+CGG24o6NaSJEnlyRKm3gSWNrzumXyv0Sjwckrp58APIuL7TISr9zx/mVJ6AngCYPXq1Z11+qEkSZOqfCafLl+WZb4acGNE9EXEVcBdwPCUa55joitFRFzDxLLfSHFlSpIktac5w1RK6RywBXgBeA14OqV0LCK2RcTGycteAE5GxKvAi8AfppRONqtoSZKkdpFpZiqltA/YN+W9Rxt+TsAfTP4jSZLUNdwBXZIkKQfDlCRJGVVp8Lw2VvOcvoIYpiRJknIwTEmSJOVgmJIk6TJUaakPcKmvAIYpSZKkHAxTkiQVpPeZl8suQSUo6mw+SZKEgaob2ZmSJEnKwTAlSZJmNT4wWHYJbc1lPkmS5lC1J/hULDtTkiRJORimJEkqgIPn3cswJUmSlINhSpIkzWl8YNBB9Bk4gC5J0izmGj6vwvLehSNl1ly3puRKOpOdKUmSpBwMU5IkSTkYpiRJUmbOTV3KMCVJkpSDYUqSJCkHn+aTJGka3XiETG2s5hN982BnSpIkKQfDlCRJUg6GKUmSpBwMU5IkSTkYpiRJknIwTEmSJOVgmJIkaZ6qcMix8jNMSZIk5WCYkiRJysEwJUmSLsv4wKAHHjcwTEmSJOVgmJIkScrBMCVJki6qjdWojdXKLqOjGKYkSZpiqD5UdgnqIIYpSZKkHK4ouwBJkjqJG3VqKsOUJEmTXN7TfLjMJ0ma2Yvb3/1HmsK9piYYpiRJknIwTEmSJOXgzJQkdaPGZbtPPFxeHVIFGKYkqdvNJ1hNnaEykFVObazGmuvWlF1GR3CZT5IkKQc7U5LUDZr9NJ7LhupihilJ0rvcAkG6bC7zSZIk5WBnSpKUzXy6Vg6qqwsYpiSpSlymk1ou0zJfRNwWEa9HxPGIeGiW6/5BRKSIWF1ciZIkSe1rzs5URCwAHgNuBUaBWkQMp5RenXLd1cBWwOO0JambzdYd86m/jlIbqwG439QcsnSmbgaOp5RGUko/A54C7pjmun8FfAU4W2B9kiS1xFB9qOwS1KGyzExdD5xoeD0KfLTxgoi4CViaUtobEX9YYH2SJLWF3mdceNH0cm+NEBHvA3YCX8hw7X0RcSgiDo2Pj+e9tSRJKtn4wGDZJZQuS2fqTWBpw+ueyfcuuBr4VeCliAC4DhiOiI0ppUONvyil9ATwBMDq1atTjrolSZ3O+SlVRJYwVQNujIg+JkLUXcA/vPBhSult4JoLryPiJeCfTg1SkqSCuP2B1FbmXOZLKZ0DtgAvAK8BT6eUjkXEtojY2OwCJUlSexsfGOzq5b5Mm3amlPYB+6a89+gM196SvyxJkqTO4Nl8kiTNwSf5NBvDlCRJUg6ezSdJGez67vcvee/zt64ooRIVzc06lZdhSpKmmC44lc4n+KS2ZZiS1DWK7i7ZrSrQbGHRPajU5gxTkiqpLbtLkirJAXRJkqQc7ExJ6mqt6GDNdI9ZlwSdkVIbqY3VWHPdmrLLaFuGKUkqUK5wZoCSOpLLfJKk9vbi9nf/KZBbIqgohilJkqQcXOaTpJJMXRL82Bsn+fVlS0qqpjvZncrOuamZ2ZmSJGkWnsunudiZkqQW+tgbT7zn9cEb7iupEklFMUxJkjrH1CF0d0dXGzBMSVKJpnaqdJkaw1XGYOWclIpmmJLU8ap0dMyfj5y85D2H0qX2ZpiS1FGqFJykqhkfGOTaB7aUXUbL+TSfJElSDnamJEmahlsiKCvDlCQ1mUPmUrW5zCdJkjKpjdWojdXKLqPt2JmS1LYcNp/gE35Se7MzJUmSlIOdKUltwS6UWsENO9UMdqYkSZJysDMlSU3gE3wlmMfRMlIRDFOSWs4lvfwcSm8u95jS5XCZT5IkFWZ8YJDxgcGyy2gpO1OSJE2yI5VNbazGmuvWlF1G2zBMSVIBnJFqM43zU8DQ4g+WVIi6gct8kiRJORimJEmScnCZT1JT+eRe6/iEn1QOw5QkzZNzUpLAZT5JkqRcDFOSJEk5uMwnSZfBpT1pQm2sBjDjflPjA4Nc+8CWVpZUGjtTkqRKG3rraNklqOIMU5IkSTm4zCepMG6DoLb1gz979+e+35z2Eo+S0XzZmZIkScrBMCVJkpSDy3yS5sUlvc7grujTyLDkp2KMDwwCVP6pPsOUJM3CrRAkzcUwJUldxm7Vezl4rrycmZIkSfN2YfPObmZnStKcum0+yqW9anCzTrWKYUqSMEBJmj+X+SRJknKwMyVJqpzMS3w/+DN468fvvv7Q325OQaq0TJ2piLgtIl6PiOMR8dA0n/9BRLwaEUcj4k8jwr+NkiSpK8zZmYqIBcBjwK3AKFCLiOGU0qsNl70CrE4p/TQifh/4KnBnMwqW1FzdNmwuSXllWea7GTieUhoBiIingDuAi2EqpfRiw/UHgd8tskhJKpoD5+o98GN+uPZvlV2GKiDLMt/1wImG16OT783kHuD56T6IiPsi4lBEHBofH89epSRJTdB74MdzXyTNodAB9Ij4XWA18PHpPk8pPQE8AbB69epU5L0lSfPnruiT3vqrd392GL0w4wODlT6fL0uYehNY2vC6Z/K994iItcAjwMdTSu8UU56kZnI+SpLyy7LMVwNujIi+iLgKuAsYbrwgIv4u8K+BjSmlnxRfpiRJUnuaszOVUjoXEVuAF4AFwDdTSsciYhtwKKU0DHwN+JvAMxEB8EZKaWMT65Yk6RIeIaMyZJqZSintA/ZNee/Rhp/XFlyXJBXOJ/ik5rhw2PGa69aUXEk53AFdkjQth9KlbAxTkirNbpTUHqr8RJ9hSuoSPrknXSa3SVBGmc7mkySp3Tl8rrLYmZIqyC6UNDN3PVfRDFOSJM2lcckPXPbTeximJFWKA+dSeWpjta7cHsEwJanjGaBax+0SpEs5gC5JkpSDYUqSJCkHl/mkDtetT+65tCd1nvGBQYDKbd5pZ0qSJCkHw5QkSVIOLvNJHaRbl/Skubj7ucpkmJLUEZyRal9ul6Bu5zKfJKlreJSMmsEwJUmSClMbq1Ebq5VdRku5zCdJqrzCO1KNZ/V5Tl/XM0xJbcphc2luDp6rHRimpDZgcJqeQ+fqCI1dKrBT1YUMU1KLGZzUDXzCTxfmptZct+aSz8YHBiu1C7phSlJbsRslqdMYpqQmsgslSdVnmJJUKjtRaraW7y3lk35dx32mJEmScrAzJRXEJT1pdkUPpWfZFsEdz9UKhilJLefSnqQqMUxJktQszk/NaHxgEKASWyQYpqQG0y3Vff7WFSVUImkm7nqudmOYkubgLJQkzd9sm3dWhWFKXcuQ1FrOSUmaThV2QzdMSWoKw5OyaNaxMz7Fp1YyTKkr2IWSOsdsAauj56U8ELmy3LRTkiQpBztTqhy7UOVxaU9SNzJMqaMZnMpngFK7cV6q83T6nlOGKUlS2+voWSlVnmFKHcMuVHuwE6UynHjr/13y3tIP/Y0SKimQu6NXhmFKLZV1h3GDU3sxQEnKqzZWq+zGnYYplc7gJEmCzt3A0zAlaVp2o9RpOnrwvEuW/Kp6tIxhShJgeJKk+TJMqRAu1UlqluH3HZ/2/alD6b989hwfWOj/ran1/Funy2ZwktRufu2//zUA/+fsuUs+67iA1eXHznTi3FSH/Q1TqxmcJElFq9qTfYYpXWRw6g7ORqlTzLS8d7kq0a1SW/NvU5cyOHUPw5Oq6sLSnjrTbE/2ddrxMoapLmBw6j4GKGl2HdWtmjpDdUFFZqmqsOTXpn9zNF8Gp+5lgFJVFLW8J7WKYapDGJI0leFJ3awZS3wd1a2CSj31N9OSX6c82Zfpb0lE3Ab8MbAA+DcppT+a8vkvAd8G/h5wErgzpfTDYkuVJHW7Vs9JTRewptPWoUtNN+e3HxELgMeAW4FRoBYRwymlVxsuuwc4nVJaHhF3AV8B7mxGwVVjx0lzsQMlKZMKzFbNNj/Vzl2qLFH6ZuB4SmkEICKeAu4AGsPUHcCXJn/+D8BgRERKKRVYa8czOKlRY0g6eMN9074vdYvZ5qQ64am9jlsibGNTA9WFJ/vaWZZv+nrgRMPrUeCjM12TUjoXEW8DS4D2/zfgMhmINJv5BiEDlLrJXAPmnRCessi6RJhV1nB2yX3H/jJ/sGtxd6txhqrx58Zg1U5dqpbG5oi4D7jwn+D/NyJeb+X928w1VDBsdim/y2rwe6wOv8vK+HbDd/nt93704AOtLmbGRJklTL0JLG143TP53nTXjEbEFcAHmRhEf4+U0hOA/wkORMShlNLqsutQfn6X1eD3WB1+l9XRKd/l+zJcUwNujIi+iLgKuAsYnnLNMHD35M+bgP/ivJQkSeoGc3amJmegtgAvMLE1wjdTSsciYhtwKKU0DHwD+JOIOA6cYiJwSZIkVV6mmamU0j5g35T3Hm34+Szw28WWVnkud1aH32U1+D1Wh99ldXTEdxmuxkmSJM1flpkpSZIkzcAwVaKI6I+IgxFRj4hDEXFz2TVpfiLigYj4XxFxLCK+WnY9yicivhARKSKuKbsWzU9EfG3y38mjEbEnIj5Udk3KLiJui4jXI+J4RDxUdj1zMUyV66vAv0wp9QOPTr5Wh4mITzBxCsCvpZRWAjtKLkk5RMRSYB3wRtm1KJfvAr+aUvo7wPeBh0uuRxk1HGP3KeAjwOaI+Ei5Vc3OMFWuBHxg8ucPAj8qsRbN3+8Df5RSegcgpfSTkutRPruAf8bEv5/qUCml/SmlC1uBH2Rij0R1hovH2KWUfgZcOMaubRmmyvVPgK9FxAkmuhn+l1NnWgH8ZkS8HBH/NSKmP6VTbS8i7gDeTCn9Rdm1qFD/CHi+7CKU2XTH2F1fUi2ZeApjk0XEAeC6aT56BPgk8PmU0n+MiN9hYr+uta2sT9nM8T1eAfwy8DFgDfB0RCxz49r2NMd3+c+ZWOJTB5jtu0wp/afJax4BzgFPtrI2dRe3RijR5IHQH0oppYgI4O2U0gfm+nNqLxHxn4GvpJRenHz9l8DHUkrj5VamyxERq4A/BX46+VYPE0vvN6eUxkorTPMWEb8H/GPgkymln85xudpERPw68KWU0m9Nvn4YIKW0vdTCZuEyX7l+BHx88ue/D/zvEmvR/D0HfAIgIlYAV+Ehqx0npfQ/Ukq/klLqTSn1MrG0cJNBqjNFxG1MzL5tNEh1nCzH2LUVl/nKdS/wx5OHQ58F7iu5Hs3PN4FvRsT/BH4G3O0Sn1S6QeCXgO9ONP45mFK6v9ySlMVMx9iVXNasXOaTJEnKwWU+SZKkHAxTkiRJORimJEmScjBMSZIk5WCYkiRJysEwJUmSlINhSpIkKQfDlCRJUg7/H3E6s99vVsI1AAAAAElFTkSuQmCC",
+                    "text/plain": [
+                        "<Figure size 720x360 with 1 Axes>"
+                    ]
+                },
+                "metadata": {
+                    "needs_background": "light"
+                },
+                "output_type": "display_data"
+            }],
+            "source": [
+                "plt.figure(figsize=(10, 5))\n",
+                "for i in range(4):\n",
+                "    s = samples[\"theta\"][:, i]\n",
+                "    s = s[jnp.newaxis]\n",
+                "    plt.hist(s, bins=100, density=True, label=f\"$\\\\theta_{i}$\", alpha=0.5)\n",
+                "plt.legend()\n",
+                "None\n"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "$ P(x_i | x_{-i}, y, \\theta) = P(x, y, \\theta) / P(x_{-i}, \\theta, y) $"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "2) gaussian approx at x=mu(theta)\n",
+                "\n",
+                "* p_thetaIy = log_berry_likelihood(vars) - p_x_I_theta_y  \n",
+                "\n",
+                "* Note the last term depends on a fixed theta too\n",
+                "\n",
+                "2) p_thetaIy = log_berry_likelihood(vars) - .5 * log(-H(f(x_0)))  \n",
+                "\n",
+                "3) p_xiIy = sum(p_xiItheta_y + p_thetaIy for theta in thetas)\n",
+                "\n",
+                "* times dTheta\n",
+                "\n",
+                "* p_xiItheta_y is skew normal approximation at MAP"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "$ P(t|y) = P(x, t, y) / gaussian(P(x | t, y)) $\n",
+                "\n",
+                "$ P(x_i|t,y) = P(x, t, y) / gaussian(P(x-i|t,y)) $\n",
+                "\n",
+                "$ P(x_i | y) = \\sum(P(xi|t,y) * P(t|y) \\Delta t) $\n",
+                "\n",
+                "$ P(x_i | y) = \\sum(P(xi|t,y) * P(t|y) \\Delta t) $"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "(6,)\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "DeviceArray([[-1.03994812e+02,  0.00000000e+00,  0.00000000e+00,\n",
+                            "               0.00000000e+00,  1.00000000e+02,  9.65321387e+03],\n",
+                            "             [ 0.00000000e+00, -1.04937164e+02,  0.00000000e+00,\n",
+                            "               0.00000000e+00,  1.00000000e+02,  2.25158911e+03],\n",
+                            "             [ 0.00000000e+00,  0.00000000e+00, -1.07928795e+02,\n",
+                            "               0.00000000e+00,  1.00000000e+02,  6.33029883e+03],\n",
+                            "             [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,\n",
+                            "              -1.08560623e+02,  1.00000000e+02,  2.96381812e+03],\n",
+                            "             [ 1.00000000e+02,  1.00000000e+02,  1.00000000e+02,\n",
+                            "               1.00000000e+02, -4.00010010e+02, -2.11989219e+04],\n",
+                            "             [ 9.65321289e+03,  2.25158911e+03,  6.33029883e+03,\n",
+                            "               2.96381812e+03, -2.11989180e+04, -1.44111600e+06]],            dtype=float32)"
+                        ]
+                    },
+                    "execution_count": 16,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "y = Y_I2[-1]\n",
+                "n = N_I2[-1]\n",
+                "log_berry_likelihood = get_log_berry_likelihood(y, n)\n",
+                "grad = jax.grad(log_berry_likelihood, 0)\n",
+                "hess = jax.jacobian(grad)\n",
+                "# theta = jnp.zeros(4)\n",
+                "key = jax.random.PRNGKey(0)\n",
+                "theta = jax.random.uniform(key, [4])\n",
+                "mu = jnp.zeros(1)\n",
+                "sigma = jnp.array(0.01)[jnp.newaxis]\n",
+                "vars = jnp.concatenate([theta, mu, sigma])\n",
+                "print(vars.shape)\n",
+                "jnp.exp(log_berry_likelihood(vars))\n",
+                "grad(vars)\n",
+                "h = hess(vars)\n",
+                "h\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "N_ARMS = 4\n",
+                "\n",
+                "\n",
+                "def pack_vars(theta, mu, sigma):\n",
+                "    return jnp.concatenate([theta, mu, sigma])\n",
+                "\n",
+                "\n",
+                "def unpack_vars(vars):\n",
+                "    return vars[:N_ARMS], vars[N_ARMS], vars[N_ARMS + 1]\n",
+                "\n",
+                "\n",
+                "# print(hs.shape)\n",
+                "@jax.jit\n",
+                "def chol():\n",
+                "    hs = jnp.stack([h for i in range(4 * 16)])\n",
+                "    return jax.lax.linalg.cholesky(\n",
+                "        hs,\n",
+                "    )\n",
+                "    # return jnp.linalg.inv(hs)\n",
+                "\n",
+                "\n",
+                "# %timeit chol()\n",
+                "\n",
+                "# @jax.jit\n",
+                "def optimize(theta, sigma, mask):\n",
+                "    log_berry_likelihood = get_log_berry_likelihood(y, n)\n",
+                "    grad = jax.grad(log_berry_likelihood, 0)\n",
+                "    hess = jax.jacobian(grad)\n",
+                "    # theta = jnp.zeros(4)\n",
+                "    mu = jnp.zeros(1)\n",
+                "    sigma = jnp.array(sigma)[jnp.newaxis]\n",
+                "    vars = pack_vars(theta, mu, sigma)\n",
+                "    # Do a newton iteration\n",
+                "    pvars = None\n",
+                "    for _ in range(10):\n",
+                "        g = grad(vars)\n",
+                "        h = hess(vars)\n",
+                "        g = g[mask]\n",
+                "        h = h[mask, mask]\n",
+                "        pvars = vars\n",
+                "        print(jnp.diag(h))\n",
+                "        update = jnp.linalg.solve(h, g)\n",
+                "        vars = vars.at[mask].add(-update)\n",
+                "        # assert not jnp.isnan(vars).any()\n",
+                "        # print(jnp.linalg.norm(pvars - vars))\n",
+                "    return vars\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n",
+                        "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
+                        " -4.0000000e+08]\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "text/plain": [
+                            "DeviceArray([-1.5039762e+00, -1.5039762e+00, -1.5039762e+00,\n",
+                            "             -1.5039761e+00, -1.5039762e+00,  9.9999999e-09],            dtype=float32)"
+                        ]
+                    },
+                    "execution_count": 26,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "theta = jnp.zeros(4)\n",
+                "sigma = 1e-8\n",
+                "mask = jnp.s_[0:5]\n",
+                "optimize(theta, sigma, mask)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "sigmas = jnp.power(10, jnp.linspace(-8, 3, 10))\n",
+                "thetas = jnp.linspace(-10, 10, 10)\n",
+                "mask = jnp.s_[1:5]\n",
+                "varss = []\n",
+                "for sigma in sigmas:\n",
+                "    for theta in thetas:\n",
+                "        theta = jnp.zeros(4).at[0].set(theta)\n",
+                "        vars = optimize(theta, sigma, mask)\n",
+                "        varss.append(vars)\n",
+                "varss = jnp.stack(varss)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                "data": {
+                    "text/plain": [
+                        "(100, 6)"
+                    ]
+                },
+                "execution_count": 6,
+                "metadata": {},
+                "output_type": "execute_result"
+            }],
+            "source": [
+                "varss.shape\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "data": {
+                        "text/plain": [
+                            "<matplotlib.collections.PathCollection at 0x1683349a0>"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                },
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAfgUlEQVR4nO3dfZBcdZ3v8fc3kxkcUDNAAphJYrKI1AUSiPQGreCqgDx6TTarEbb04roasUQvWxbcIFu5QF0rkbhSKO6yucgt9YrALiaggOHJWl2qYDMhyDMrT1ky4WGQJOBmIJnku390TzLT0z3DZPqc8+35fV5Vqen+9Znpz0yS853zezrm7oiISLomFB1ARESKpUIgIpI4FQIRkcSpEIiIJE6FQEQkcROLDrAvJk+e7DNnziw6hohIU1m/fv2r7j6lur0pC8HMmTPp6uoqOoaISFMxs4212tU1JCKSOBUCEZHEqRCIiCROhUBEJHEqBCIiiWvIrCEzuw74BPCKux9TaTsIuBGYCTwPLHb3LTU+91zgbytP/4+7/6gRmaqt2dDNyrVPsXlrL1M72rnwtCNZOLczi7dSjibKICJgjdh91Mz+DPgj8OMBheAK4DV3X2FmS4ED3f1/VX3eQUAXUAIcWA8cX6tgDFQqlXw000fXbOjm4p8/Qu/OXXva2ltbWL5odq4nHuWIlWFgFhUkSYGZrXf3UnV7Q7qG3P03wGtVzQuA/t/ufwQsrPGppwF3uftrlZP/XcDpjcg00Mq1Tw064QD07tzFyrVPNfqtlKOJMsDegtS9tRcHurf2cvHPH2HNhu5cc4gUKcsxgkPd/cXK45eAQ2sc0wm8MOD5pkrbEGa2xMy6zKyrp6dnVEE2b+0dVXtWlCNWBohTkESKlMtgsZf7n8bUB+Xuq9y95O6lKVOGrJAe1tSO9lG1Z0U5YmWAOAVJpEhZFoKXzew9AJWPr9Q4phuYPuD5tEpbQ1142pG0t7YMamtvbeHC045s9FspRxNlgDgFSaRIWRaCW4FzK4/PBW6pccxa4FQzO9DMDgROrbQ11MK5nSxfNJvOjnYM6OxoL2RQUjliZYA4BUmkSI2aNfQz4KPAZOBl4H8Da4CbgBnARsrTR18zsxJwnrt/sfK5XwC+WflS33L3/zfS+4121pDIcDRrSFJRb9ZQQwpB3lQIRERGr14haMptqEXGI12ZSFFUCEQCqF5g17+eAVAxkMxpryGRALSeQYqkQiASgNYzSJFUCEQC0HoGKZIKgUgAWs8gRdJgsUgA/QPCmjUkRVAhEAli4dxOnfilEOoaEhFJnAqBiEjiVAhERBKnQiAikjgVAhGRxCUzayjKhl7KESuDiCRSCKJs6KUcsTIMzKKCJClLomsoyoZeyhErA+wtSN1be3H2FqQ1Gxp+x1SRsDItBGZ2pJk9NODP62Z2QdUxHzWzbQOOWdboHFE29FKOWBkgTkESKVKmXUPu/hRwHICZtVC+Mf3qGof+1t0/kVWOqR3tdNc4weS9oZdyxMoAcQqSSJHy7Bo6GXjG3Tfm+J5AnA29lCNWBtCunyKQbyE4G/hZndc+ZGa/M7M7zOzoWgeY2RIz6zKzrp6enlG98cK5nSxfNJvOjnYM6OxoZ/mi2bkPCCpHrAwQpyCJFCmXm9ebWRuwGTja3V+ueu3dwG53/6OZnQlc5e5HDPf1dPN6aSTNGpJUFH3z+jOAB6uLAIC7vz7g8e1m9vdmNtndX80pmyROu35K6vIqBOdQp1vIzA4DXnZ3N7N5lLur/pBTLpEwdGUiRcm8EJjZAcDHgS8PaDsPwN2vAT4FfMXM+oBe4GzPo79KJJBIC+wkPZkXAnf/T+DgqrZrBjy+Grg66xwikQ23nkGFQLKWxMpikei0nkGKpEIgEoDWM0iRVAhEAtB6BilSEruPikTXPw6gWUNSBBUCkSC0nkGKoq4hEZHEqRCIiCROhUBEJHEqBCIiiVMhEBFJXDKzhqJs6KUcsTKISCKFIMqGXsoRK8PALCpIkrIkuoai3KBcOWJlgL0FqXtrL87egrRmQ3euOUSKlEQhiLKhl3LEygBxCpJIkZIoBFE29FKOWBkgTkESKVIShSDKhl7KESsDxClIEtTDN8GVx8ClHeWPD980LnNkXgjM7Hkze8TMHjKzIXect7LvmdnTZvawmX2g0RkWzu1k+aLZdHa0Y0BnRzvLF83OfUBQOWJlgDgFSWoo+iT88E3wi6/DthcAL3/8xdfHZQ7L+q6QZvY8UKp3M3ozOxP4GnAmcAJwlbufMNzXLJVK3tU1pKaI7BPNGgqo/+S3c0AXXWs7/PfvwZzF+WS48pjKybfKpOnwN4/mk6HBOcxsvbuXqtsjTB9dAPy4cp/i+82sw8ze4+4vFh1M0qBdPwO65/LBRQDKz++5PL9CsG3T6NqbOEceYwQO3Glm681sSY3XO4GB5W5TpW0QM1tiZl1m1tXT05NRVJHirNnQzfwV9zJr6W3MX3Fv2lNYI5yEJ00bXXsT58ijEJzo7h8AzgC+amZ/ti9fxN1XuXvJ3UtTpkxpbEKRgmk9Q5UIJ+GTl5W7owZqbS+35ymHHJkXAnfvrnx8BVgNzKs6pBuYPuD5tEqbSDK0nqFKhJPwnMXlMYlJ0wErf8xzjCLHHJmOEZjZAcAEd3+j8vhU4PKqw24FzjezGygPFm/T+ICkRusZqvSf5O65vNwdNGlauQgUcRLO+z0LyJH1YPGhwGoz63+v6939V2Z2HoC7XwPcTnnG0NPAduCvMs4kEs7Ujna6a5z0k17PEOUknIBMC4G7PwscW6P9mgGPHfhqljlEorvwtCMHbcIHBa5nePim4n8TjyLKzyLjHBGmj4okr3/6auHrGarn7/cvXoL0ikGUn0UOOTJfUJYFLSgTyUiURVRQ/G/jUX4WiSwoE5EoIszfhxi/jUf5WYyTBWUi0iwizN+H4VcW5yXKz2KcLCgTkWYRYf4+xPht/IhTR9fexDlUCERkryiLqNoPHF17Fn5/5+jamziHxghEZDDN3y+LcFWSU45kCkGUrYaVI1YGqaHo2ToAvVtG156FSdPqzNYpYIwg4xxJdA1F2dBLOWJlGJhFu35WRLkZS4SB2pOXwYTWwW0TWovZdC7jHEkUgigbeilHrAwQqyCFEGG2DsQZtC5vj1P/+TjJkUQhiLKhl3LEygBxClIYUfrF5yyGY/8SrHIbUWspP8+zi+qey2HXjsFtu3bkXxRzyJFEIYhyg3LliJUB4hSkMCJ0yUC5K+p314NXirTvKj/Ps4sqSlHUgrLGiHKDcuWIlQHiFKQwonTJROiiilIUtaCsMRbO7WT5otl0drRjQGdHO8sXzc59hopyxMoAcQpSGHMWs272ZbzEFHa78RJTWDf7svxnDUX4bfzkZdDSNritpa2YweKMcyQzfTTKDcqVI14GCLDrZxBrNnRz8br30rvzqj1t7etaWD69O9+fSfuB0Pta7fY8VW/KWdQmnRnnyKwQmNl04MeUb07jwCp3v6rqmI8CtwDPVZp+7u45j8RI6iIUJIixrmLl2qf4+K5/4aK2m5hqr7LZJ3NF32JWrm0L8TPK1T2Xw+6dg9t27yy35z1onXGOLK8I+oBvuPuDZvYuYL2Z3eXuj1cd91t3/0SGOUTC65/G2j+DqX8aK5DrCbj0+l2sbF1Fm/UBMM1e5Tutq7jwdYCTcssRYkFZhO6pnHJkNkbg7i+6+4OVx28ATwCJ/Uoh8vZEmcZ6WdtP9hSBfm3Wx2VtP8k1R4iB2ggZcsqRy2Cxmc0E5gIP1Hj5Q2b2OzO7w8yOHuZrLDGzLjPr6unpySqqSCGiTGOdxBujas9MhNlL2n20cczsncDNwAXu/nrVyw8C73X3Y4HvA2vqfR13X+XuJXcvTZkyJbO8IkWIMo213nrV3NfTRlhQltDuo5kWAjNrpVwEfuruP69+3d1fd/c/Vh7fDrSa2eQsM4lEFGYaa/tBo2vPihaU5Zojs0JgZgb8EHjC3b9b55jDKsdhZvMqef6QVSaRqKKsq3jmkFNrzlR85pCcu0O0oCzXHFnOGpoPfA54xMweqrR9E5gB4O7XAJ8CvmJmfUAvcLZ7URN1RYoVYRrrARvvqbm/2QEb78k3SITfxk9eBrd8dfA+P0UtKMs4R2aFwN3/lRG6Ft39auDqrDKIyOgc4j01/9ce4q/mG0QLynLNkcQWEyLy9rxu76rT/s6ckwQw3EKucZZDhUBE9qgesB6pPTNaUJZrDhUCEdljv53bRtWele3th42qPRMJDRarEIjIXvX64HPum79i52d4ywdfhbzlLVyx8zP5hTjiVKp74r3SnqvxsKBMRGS0tmzfgVWNWhvGlu076nxG421/7PYh4+ZWac9VDgvKktmGOsLOjsoRL0OkHBF475aaU/3qtWfl4rZ/oo2hex5d3PZPwPJcMryj96VRtWfFt22q/XdSp31fJFEIouzsqByxMkTKEcXLTOYwhu7lVW7Pz6HUnq5arz0LW/0ADrI/1m7PLQVs45101NjrqdzeGEl0DUXZ2VE5YmWIlCOK5Ts+XbNvfvmOT+eaw+qMSdRrz8KE6pV1I7RnZdfu2msG6rXviyQKQZSdHZUjVoZIOaI4cP+2mn3zB+7fVuczsvFW365RtWdhEkOvBoZrz8qBE/5zVO37IolCEGVnR+WIlSFSjiguar2x5v0ILmq9MdccrTurNyoevj0LEa5KAHa2vntU7fsiiUIQZWdH5YiVIVIOKI9XzF9xL7OW3sb8FfeyZkN37hn2731xVO1Z2bL7gFG1Z+Gtvt2jas9O9puDJzFYHOUG5coRK0OkHGs2dDN59WL+1R6F/YBeuG/1MazhpnyzWMverZ+r23PUMqH2Sa5eexZa6yyiq9fezDmsGTf7LJVK3tXVVXQMkYZ54NIPM88fHrTzpzv8m83hhEt/m1+QSycN81p+J0C/tAMbspwLHMMu3ZpLhk3LDmfahKGzlDbtnsy0y5/JJUOjc5jZencvVbcn0TUkEl11EYDy9s/z/OFcc2xvf8+o2rNidbZPqNeehWvbPst2HzxIvt3buLbts7llyCuHCoFIBEHuEXnHm8fW3PH4jjePzTXHusO/Rm/Vya/X21h3+Ndyy3DcWUu4ZNeX2LR7Mrvd2LR7Mpfs+hLHnbUktwz9OZb5kkE5lvmShuZIYoxARN6eE3Z1YVW/HpqV2/N0weNHcPzOL3LRxJuYan9gsx/MFX2LWf/4Edz3yfxy/HL3iazum7/neesE4yP5vT1QHsfq2ng2H3lgPrvcaTHjnBOmN3TsKPNCYGanA1cBLcC17r6i6vX9gB8Dx1O+TeVn3P35hgep1feZY5+ncgTNECRHkAsCpk6ofafYeu1Z2by1l25O5NYdJw5qtxzXd6xc+xQ7qxZt7dztrFz7VO6r329e382uyqXaLnduXt9N6b0HNSxH1jevbwF+AJwBHAWcY2ZHVR3218AWd38fcCXw7YYHqTcANtzAWBaUI1aGSDmCeLPONs/12rMSYX1HlMWGeax+z3qMYB7wtLs/6+47gBuABVXHLAB+VHn8z8DJ/Te0F5F87X/G5fS1vGNQW1/LO9j/jHzvyhVhfUeEYgT5FKSsC0En8MKA55sqbTWPcfc+YBtwcPUXMrMlZtZlZl09PUM3xRKRBpizmIkLvg+TpgMGk6aXn89ZnGuMhXM7+YvjO2mp/E7YYsZfHN+Za5dMhGIE+RSkppk15O6r3L3k7qUpU6YUHUeksSbUGa6r156hNbvmM/+t7zHrzZ8y/63vsWbX/JE/qdEZ6vSL57naOkIxgnJBam0Z3EnS2mINLUhZF4JuYPqA59MqbTWPMbOJwCTKg8Yi6Vj4DwwdGrZKe376t+Xu3tqLs3db7ry3u4iwK2yEYrRHzVulNU7WhWAdcISZzTKzNuBs4NaqY24Fzq08/hRwrzd6uXO9GSC5z5JRjlAZIuWYsxgWrRrUJcOiVbl3yUQ4AUOMgdooP4vhZi81SqbXne7eZ2bnA2spTx+9zt0fM7PLgS53vxX4IfATM3saeI1ysWi8IqYl1qIcsTJAnBxzFud+4q8W4QQM5f7v7hrvmeKsofEwWIy73+7u73f3w939W5W2ZZUigLu/6e6fdvf3ufs8d38260wiUluUmTJ59IuPJMrPQoPFIpKrKDNlgMz7xUcSoRjllUOFQET2WDi3k+WLZtPZ0Y4BnR3tLF80O/eZMnn0i78tBRejuu/b4BzJ7DW0ZkN34XvOK0e8DMox1MK5+U+RrBahfz7KFhN55EiiEPRPieufAdA/JQ7Ifc8Q5YiTQTnqZym6IGmwON8cSXQNRZoGphxxMijHUFHWEUQYq9Bg8TiTUmVvlhwRMijHUFEKUoRVvRGKUV45kigEKVX2ZskRIYNyDBWlIEVY1RuhGOWVI4lCkFJlb5YcETIox1BRClKEK5MIxSivHEkUgihT4pQjVgblGCpKQYpwZRKhGOWVwxq9rU8eSqWSd3Xle+s8kVREmDU0f8W9NWcNdXa0c9/Sk3LJMGvpbTWn6xvw3IqzcsnQ6Bxmtt7dS9XtSUwfFZG3L8I6ggtPO3LQdFooZtZQ0VNY88qRRNeQiDSXCAO1KW0xoSsCERkkQtdQHjdsf1sS2WJCVwQiskeUBWURBmqj7HeURw4VAhHZI8IJGGLMGoqQIa8cKgQiskeUk1+E9QwRMuSVI5NCYGYrzexJM3vYzFabWUed4543s0fM7CEz03xQkYJFOflFWM8QIUNeObK6IrgLOMbd5wD/Dlw8zLEfc/fjas1tFZF8RTn5RZg1FCFDXjkyKQTufqe791We3g9My+J9RKSxoqxwjrC9Q4QMeeXIfGWxmf0CuNHd/3+N154DtlCeDPWP7r5qmK+zBFgCMGPGjOM3btyYUWIRKVqElcURMjQ6R8NXFpvZ3cBhNV66xN1vqRxzCdAH/LTOlznR3bvN7BDgLjN70t1/U+vASpFYBeUtJvY1t4jEF2HQOkKGvHLscyFw91OGe93MPg98AjjZ61x2uHt35eMrZrYamAfULAQiko4I2ztEyJBXjqxmDZ0OXAR80t231znmADN7V/9j4FTg0SzyiDSDNRu6mb/iXmYtvY35K+7NvS86kgiD1tpiYuyuBvaj3N0DcL+7n2dmU4Fr3f1M4FBgdeX1icD17v6rjPKIhKZ7Fg+2cG4nXRtf42cPvMAu98Jm7KSyxUQmhcDd31enfTNwZuXxs8CxWbx/LRH+cStHvAxRcgy3ojfPLFEKUoS9hobb2iHPn0UeOZJYWRxl/xTliJUhUo4oA5NRtpiIkCPK34m2mGiQCP+olCNehkg5oqzoTenkN5IofydNu8VENBH+USlHvAyRckQYHIW0Tn4jifJ30sxbTIQS4R+VcsTLEClHlBW9KZ38RqItJsaZCP+olCNehkg5oPwf/r6lJ/HcirO4b+lJhQycRylIEU7CKW0xkcQdyvr/8RQ9M0Q5YmWIlCOSCPcsjjJrKMJMrjxyZL7XUBZKpZJ3dWnXapHxKsI+P7OW3lZzur4Bz604K5cMjc5Rb6+hJLqGRKS5RBjEjzJ+pFlDIpKkCCfhKONHmjUkIkmKcBKONHCedQ6NEYjIIBG23IiUYzxp+P0IRGT8ibLXUP/76cSfD3UNicgeUbbckHypEIjIHhFm60j+VAhEZI8Is3Ukf5kVAjO71My6zeyhyp8z6xx3upk9ZWZPm9nSrPKIyMgizNaR/GU9WHylu3+n3otm1gL8APg4sAlYZ2a3uvvjGecSkRq05Uaaip41NA94unK3MszsBmABoEIgUhDN1klP1oXgfDP7H0AX8A1331L1eifwwoDnm4ATan0hM1sCLAGYMWNGBlFFiqV581KUMY0RmNndZvZojT8LgH8ADgeOA14E/m4s7+Xuq9y95O6lKVOmjOVLiYQT5ZaZkqYxXRG4+ylv5zgz+7/AL2u81A1MH/B8WqVNJClRtjyWNGXWNWRm73H3FytP/xx4tMZh64AjzGwW5QJwNvCXWeSJctmtHLEyRMmh+ftSpCzHCK4ws+MAB54HvgxgZlOBa939THfvM7PzgbVAC3Cduz/W6CBRls0rR6wMkXJM7Wivuf++5u9LHjJbR+Dun3P32e4+x90/2X914O6b3f3MAcfd7u7vd/fD3f1bWWSJsmxeOWJliJRD8/elSEVPH81FlMtu5YiVIVIOzd+XIiVRCKJcditHrAyRckCc+fsRxkwkX0nsNRTlsls5YmWIlCMKTWNNUxJXBFEuu5UjVoZIOaLQNNY06Q5lIrLHrKW3UeuMYMBzK87KO440WL07lCXRNSQib4+2oU6TCoGI7KExkzQlMUYgIm+PxkzSpEIgIoNEmcYq+VHXkIhI4lQIREQSp0IgIpI4FQIRkcSpEIiIJE6FQEQkcSoEIiKJy2QdgZndCPQvRewAtrr7cTWOex54A9gF9NXaA0MkFdr+WYqSSSFw98/0PzazvwO2DXP4x9z91SxyiDSLKLfMlDRl2jVkZgYsBn6W5fuINLsot8yUNGW9xcSHgZfd/fd1XnfgTjNz4B/dfVW9L2RmS4AlADNmzBh1kCiX3coRK0OUHFFumSlp2udCYGZ3A4fVeOkSd7+l8vgchr8aONHdu83sEOAuM3vS3X9T68BKkVgF5fsRjCZrlMtu5YiVIVKOSLfMlPTsc9eQu5/i7sfU+HMLgJlNBBYBNw7zNborH18BVgPz9jXPcKJcditHrAyRcmj7ZylSlmMEpwBPuvumWi+a2QFm9q7+x8CpwKNZBIly2a0csTJEyrFwbifLF82ms6MdAzo72lm+aLYGiiUXWY4RnE1Vt5CZTQWudfczgUOB1eXxZCYC17v7r7IIEuWyWzliZYiUA7T9sxQnsysCd/+8u19T1ba5UgRw92fd/djKn6Pd/VtZZYly2a0csTJEyiFSpCRuTBPlrkvKEStDpBwiRTL3UU3ACaFUKnlXV1fRMUREmoqZra+1g4P2GhIRSZwKgYhI4lQIREQSp0IgIpI4FQIRkcSpEIiIJE6FQEQkcSoEIiKJUyEQEUmcCoGISOJUCEREEpfEpnMizSDCLTMlTSoEIgFEuWWmpEldQyIBRLllpqRpTFcEZvZp4FLgvwHz3L1rwGsXA38N7AK+7u5ra3z+LOAG4GBgPfA5d98xlkz1RLnsVo5YGaLkiHLLTEnTWK8IHqV8g/rfDGw0s6Mo36ryaOB04O/NrGXop/Nt4Ep3fx+whXLhaLj+y+7urb04ey+712zozuLtlKNJMkTKUe/WmEXcMlPSM6ZC4O5PuHuta9cFwA3u/pa7Pwc8DcwbeICVb1Z8EvDPlaYfAQvHkqeeKJfdyhErQ6QcumWmFCmrMYJO4IUBzzdV2gY6GNjq7n3DHLOHmS0xsy4z6+rp6RlVmCiX3coRK0OkHAvndrJ80Ww6O9oxoLOjneWLZmugWHIx4hiBmd0NHFbjpUvc/ZbGR6rN3VcBq6B8q8rRfO7Ujna6a/zHzvuyWzliZYiUA8rFQCd+KcKIVwTufoq7H1Pjz3BFoBuYPuD5tErbQH8AOsxs4jDHNESUy27liJUhUg6RImW1juBW4Hoz+y4wFTgC+LeBB7i7m9mvgU9Rnjl0LpDJFUb/b1lFzwxRjlgZIuUQKZK5j6qXZfAnm/058H1gCrAVeMjdT6u8dgnwBaAPuMDd76i03w580d03m9mfUC4CBwEbgM+6+1sjvW+pVPKurq6RDhMRkQHMbL27l4a0j6UQFEWFQERk9OoVAq0sFhFJnAqBiEjiVAhERBKnQiAikrimHCw2sx5g4z5++mTg1QbGiWQ8f28wvr8/fW/Nq5m+v/e6+5TqxqYsBGNhZl21Rs3Hg/H8vcH4/v70vTWv8fD9qWtIRCRxKgQiIolLsRCsKjpAhsbz9wbj+/vT99a8mv77S26MQEREBkvxikBERAZQIRARSVyShcDMjjOz+83socpdz+aN/FnNw8y+ZmZPmtljZnZF0Xkazcy+YWZuZpOLztJIZray8vf2sJmtNrOOojONlZmdbmZPmdnTZra06DyNYmbTzezXZvZ45f/Z/yw601gkWQiAK4DL3P04YFnl+bhgZh+jfM/oY939aOA7BUdqKDObDpwK/EfRWTJwF3CMu88B/h24uOA8Y2JmLcAPgDOAo4BzzOyoYlM1TB/wDXc/Cvgg8NVm/t5SLQQOvLvyeBKwucAsjfYVYEX/fR3c/ZWC8zTalcBFlP8OxxV3v3PAPbzvp3zXvmY2D3ja3Z919x2U7z2yoOBMDeHuL7r7g5XHbwBPMMw916NLtRBcAKw0sxco/8bc1L95VXk/8GEze8DM/sXM/rToQI1iZguAbnf/XdFZcvAF4I6iQ4xRJ/DCgOebaOKTZT1mNhOYCzxQcJR9ltWtKgtnZncDh9V46RLgZOBv3P1mM1sM/BA4Jc98YzHC9zaR8h3fPgj8KXCTmf2JN8k84RG+t29S7hZqWsN9f/33Aa/c3a8P+Gme2WT0zOydwM2U78L4etF59lWS6wjMbBvQUblvsgHb3P3dI31eMzCzXwHfdvdfV54/A3zQ3XuKTTY2ZjYbuAfYXmmaRrlLb567v1RYsAYzs88DXwZOdvftIxwempl9CLh0wO1rLwZw9+WFBmsQM2sFfgmsdffvFp1nLFLtGtoMfKTy+CTg9wVmabQ1wMcAzOz9QBvNszNiXe7+iLsf4u4z3X0m5W6GD4yzInA65fGPTzZ7EahYBxxhZrPMrA04G7i14EwNUfkF8ofAE81eBGAcdw2N4EvAVWY2EXgTWFJwnka6DrjOzB4FdgDnNku3kHA1sB9wV/k8w/3ufl6xkfadu/eZ2fnAWqAFuM7dHys4VqPMBz4HPGJmD1XavunutxcXad8l2TUkIiJ7pdo1JCIiFSoEIiKJUyEQEUmcCoGISOJUCEREEqdCICKSOBUCEZHE/Rd0J8TsH9lx7gAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<Figure size 432x288 with 1 Axes>"
+                        ]
+                    },
+                    "metadata": {
+                        "needs_background": "light"
+                    },
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "sigmas = jnp.log10(varss[:, N_ARMS + 1])\n",
+                "thetas = varss[:, :N_ARMS]\n",
+                "plt.scatter(sigmas, jnp.mean(thetas, 1))\n",
+                "plt.scatter(sigmas, jnp.std(thetas, 1))\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "data": {
+                        "text/plain": [
+                            "<matplotlib.collections.PathCollection at 0x29596a520>"
+                        ]
+                    },
+                    "execution_count": 81,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                },
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAD4CAYAAAAUymoqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAeyUlEQVR4nO3df3Dc9X3n8eerwhBBfojYOET+cRDI6KDGjumOSxvASc1YxvXEjnPX0KMEzhSXK7mDGyIO4RnaKVNSqmtpbyjN+OzcXVuuyTXIJk2gsklS0hnOvsj4h0xsGQiUeA2xIShp8E4jK+/74/uRuxa7kr7elWRJr8eMx9rP572f/Xy/Wuvl7+ez2lVEYGZmlsfPTfQEzMxs8nF4mJlZbg4PMzPLzeFhZma5OTzMzCy3syZ6AuNl1qxZcdFFF030NMzMJo1du3a9EREXVOqbNuFx0UUX0d3dPdHTMDObNCT9Y7U+L1uZmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5TZtXm1lZjadbN1dpKOrlyN9JZqbGmlrbWHN4jl1G9/hYWY2xWzdXaS9s4dS/wAAxb4S7Z09AHULEC9bmZlNMR1dvSeDY1Cpf4COrt66PYbDw8xsijnSV8rVfjpqCg9JHZIOStonaYukpip1d0raL+l5SXdV6L9bUkialW7fmMbskfSspEVltSsk9Up6UdK9tczfzGwqam5qzNV+Omq98tgOLIiIhcAhoH1ogaQFwG3AEmARsErSpWX984DlwKtld3sZWBoRVwAPABtTbQPwZ8D1wOXAr0u6vMZjMDObUtpaW2ic0XBKW+OMBtpaW+r2GDWFR0Rsi4gT6eYOYG6FssuAnRFxPNU+A6wt638YuAc4+Xm4EfFsRLxVYdwlwIsR8b2I+CnwJWB1LcdgZjbVrFk8h8+vvYI5TY0ImNPUyOfXXnHGvtpqHfDlCu37gd+XNBMoASuBbgBJq4FiROyVVG3cW4Gn0tdzgO+X9R0GfrHaHSWtB9YDzJ8/f9QHYmY22a1ZPKeuYTHUiOEh6WngwgpdGyLiiVSzATgBPDa0KCIOSHoI2Aa8DewBBiSdC9xHtmRV7bE/ThYeV494JBVExEbSklehUIgRys3MbJRGDI+IuG64fkm3AKuAZRFR8Qd0RGwGNqf6B8muGC4BLgYGrzrmAs9JWhIRr0taCGwCro+IN9NQRWBe2dBzU5uZmY2jmpatJK0g269YGhHHh6mbHRFHJc0n2++4KiL6gNllNa8AhYh4I9V1AjdFxKGyob4DfFjSxWShcQPw72o5BjMzy6/WPY9HgHOA7enqYUdE3C6pGdgUEStT3eNpz6MfuCMFx3DuB2YCj6ZxT0REISJOSPos0AU0AF+MiOdrPAYzM8tJVVaappxCoRD+JEEzs9GTtCsiCpX6/BvmZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWWz3fkt3MbNrburtIR1cvR/pKNDc10tbaMqZvjT5RHB5mZnWydXeR9s4eSv0DABT7SrR39gBMuQDxspWZWZ10dPWeDI5Bpf4BOrp6J2hGY8fhYWZWJ0f6SrnaJzOHh5lZnTQ3NeZqn8wcHmZmddLW2kLjjIZT2hpnNNDW2jJBMxo73jA3M6uTwU1xv9rKzMxyWbN4zpQMi6FqWraS1CHpoKR9krZIaqpSd6ek/ZKel3RXhf67JYWkWen2jWnMHknPSlqU2udJ+pak76ax7qxl/mZmdnpq3fPYDiyIiIXAIaB9aIGkBcBtwBJgEbBK0qVl/fOA5cCrZXd7GVgaEVcADwAbU/sJ4O6IuBy4CrhD0uU1HoOZmeVUU3hExLaIOJFu7gDmVii7DNgZEcdT7TPA2rL+h4F7gJMfph4Rz0bEW0PHjYjXIuK59PU/AQeAqX99aGZ2hqnnq63WAU9VaN8PXCNppqRzgZXAPABJq4FiROwdZtxbK40r6SJgMbCzxnmbmVlOI26YS3oauLBC14aIeCLVbCBbUnpsaFFEHJD0ELANeBvYAwykILmPbMmq2mN/nCw8rh7S/m7gceCuiPjxMPdfD6wHmD9/fvWDNDOzXBQRI1cNN4B0C/BbwLKIOD6K+geBw8A/AN8ABu8zFzgCLImI1yUtBLYA10fEobL7zwC+BnRFxB+Pdp6FQiG6u7tHW25mNu1J2hURhUp9Nb1UV9IKsv2KpcMFh6TZEXFU0nyy/Y6rIqIPmF1W8wpQiIg3Ul0ncNOQ4BCwGTiQJzjMzKy+at3zeAR4D7Bd0h5JXwCQ1CzpybK6xyV9F/hb4I4UHMO5H5gJPJrGHbxk+ChwE/ArqX2PpJU1HoOZmeVU87LVZOFlKzOzfIZbtvJ7W5mZWW4ODzMzy83hYWZmuTk8zMwsN4eHmZnl5rdkN7MpY+vu4rT4LI0zgcPDzKaErbuLtHf2UOofAKDYV6K9swfAATIGvGxlZlNCR1fvyeAYVOofoKOrd4JmNLU5PMxsSjjSV8rVbrVxeJjZlNDc1Jir3Wrj8DCzKaGttYXGGQ2ntDXOaKCttWWCZjS1ecPczKaEwU1xv9pqfDg8zGzKWLN4jsNinHjZyszMcnN4mJlZbg4PMzPLzeFhZma5OTzMzCy3msJDUoekg5L2SdoiqalK3Z2S9kt6XtJdFfrvlhSSZqXbN6YxeyQ9K2nRkPoGSbslfa2W+ZuZ2emp9cpjO7AgIhYCh4D2oQWSFgC3AUuARcAqSZeW9c8DlgOvlt3tZWBpRFwBPABsHDLsncCBGuduZmanqabwiIhtEXEi3dwBzK1QdhmwMyKOp9pngLVl/Q8D9wBRNu6zEfFWpXElzQV+FdhUy9zNzOz01XPPYx3wVIX2/cA1kmZKOhdYCcwDkLQaKEbE3mHGvXXIuH9CFjY/G2lCktZL6pbUfezYsdEdhZmZjWjE3zCX9DRwYYWuDRHxRKrZAJwAHhtaFBEHJD0EbAPeBvYAAylI7iNbsqr22B8nC4+r0+1VwNGI2CXpYyPNPSI2kpa8CoVCjFBuZmajNGJ4RMR1w/VLugVYBSyLiIo/oCNiM7A51T8IHAYuAS4G9kqCbGnqOUlLIuJ1SQvJlqauj4g301AfBT4haSXwLuC9kv4qIn5jxCM1M7O6qem9rSStIFtCWhoRx4epmx0RRyXNJ9vvuCoi+oDZZTWvAIWIeCPVdQI3RcShwZqIaCdtyqcrj885OMzMxl+tb4z4CHAOsD1dPeyIiNslNQObImJlqntc0kygH7gjBcdw7gdmAo+mcU9ERKHGuZqZWZ2oykrTlFMoFKK7u3uip2FmNmlI2lXtP+5+S3Yzq9nW3UV/jsY04/Aws5ps3V2kvbOHUv8AAMW+Eu2dPQAOkCnM721lZjXp6Oo9GRyDSv0DdHT1TtCMbDw4PMysJkf6SrnabWpweJhZTZqbGnO129Tg8DCzmrS1ttA4o+GUtsYZDbS1tkzQjGw8eMPczGoyuCnuV1tNLw4PM6vZmsVzHBbTjJetzMwsN4eHmZnl5vAwM7PcHB5mZpabw8PMzHJzeJiZWW4ODzMzy83hYWZmuTk8zMwst5rCQ1KHpIOS9knaIqmpSt2dkvZLel7SXRX675YUkmal2zemMXskPStpUVltk6SvpMc9IOmXajkGMzPLr9Yrj+3AgohYCBwC2ocWSFoA3AYsARYBqyRdWtY/D1gOvFp2t5eBpRFxBfAAsLGs70+Bv4uIf53GO1DjMZiZWU41hUdEbIuIE+nmDmBuhbLLgJ0RcTzVPgOsLet/GLgHOPlh6hHxbES8NXRcSe8DrgU2p7qfRkRfLcdgZmb51XPPYx3wVIX2/cA1kmZKOhdYCcwDkLQaKEbE3mHGvbVs3IuBY8D/kLRb0iZJ51W7o6T1kroldR87duw0DsnMzCoZMTwkPZ32K4b+WV1WswE4ATw29P4RcQB4CNgG/B2wBxhIQXIfcP8wj/1xsvD4L6npLOBK4M8jYjHwNnBvtftHxMaIKERE4YILLhjpUM3MbJRGfEv2iLhuuH5JtwCrgGUREZVqImIzaalJ0oPAYeASsiuJvZIgW5p6TtKSiHhd0kJgE3B9RLyZhjoMHI6Inen2VxgmPMymuq27i/4cDZsQNX2eh6QVZPsVSyPi+DB1syPiqKT5ZPsdV6W9itllNa8AhYh4I9V1AjdFxKHBmhQq35fUEhG9wDLgu7Ucg9lktXV3kfbOHkr9AwAU+0q0d/YAOEBszNW65/EI8B5gu6Q9kr4AIKlZ0pNldY9L+i7wt8Ado9jkvh+YCTyaxu0u6/uPwGOS9gEfAR6s8RjMJqWOrt6TwTGo1D9AR1fvBM3IppOarjwi4tIq7UfINsYHb18zirEuKvv6N4HfrFK3ByjknKrZlHOkr5Sr3aye/BvmZpNUc1NjrnazenJ4mE1Sba0tNM5oOKWtcUYDba0tEzQjm05qWrYys4kzuCnuV1vZRHB4mE1iaxbPcVjYhPCylZmZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluNYWHpA5JByXtk7RFUlOVujsl7Zf0vKS7KvTfLSkkzUq3b0xj9kh6VtKistr/nMbZL+mvJb2rlmMwM7P8ar3y2A4siIiFwCGgfWiBpAXAbcASYBGwStKlZf3zgOXAq2V3exlYGhFXAA8AG1PtHOA/AYWIWAA0ADfUeAxmuW3dXeSjf/BNLr7363z0D77J1t3FiZ6S2biqKTwiYltEnEg3dwBzK5RdBuyMiOOp9hlgbVn/w8A9QJSN+2xEvFVl3LOARklnAecCR2o5BrO8tu4u0t7ZQ7GvRADFvhLtnT0OEJtW6rnnsQ54qkL7fuAaSTMlnQusBOYBSFoNFCNi7zDj3jo4bkQUgf9KdpXyGvCjiNhWv0MwG1lHVy+l/oFT2kr9A3R09U7QjMzG34ifJCjpaeDCCl0bIuKJVLMBOAE8NrQoIg5IegjYBrwN7AEGUpDcR7ZkVe2xP04WHlen2+cDq4GLgT7gbyT9RkT8VZX7rwfWA8yfP3+kQzUblSN9pVztZlPRiOEREdcN1y/pFmAVsCwiolJNRGwGNqf6B4HDwCVkIbBXEmRLU89JWhIRr0taCGwCro+IN9NQ1wEvR8SxNFYn8MtAxfCIiI2k/ZJCoVBxbmZ5NTc1UqwQFM1NjRMwG7OJUeurrVaQ7Vd8IiKOD1M3O/09n2y/439HRE9EzI6IiyLiIrJAuTIFx3ygE7gpIg6VDfUqcJWkc5UlzjLgQC3HYJZXW2sLjTMaTmlrnNFAW2vLBM3IbPyNeOUxgkeAc4Dt6ephR0TcLqkZ2BQRK1Pd45JmAv3AHRHRN8K49wMzgUfTuCciohAROyV9BXiObJlsN+nKwmy8rFk8B8j2Po70lWhuaqStteVku9l0oCorTVNOoVCI7u7uiZ6GmdmkIWlXRBQq9fk3zM3MLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVlutX6eh9m42rq76M/RMDsDODxs0ti6u0h7Zw+l/gEAin0l2jt7ABwgZuPMy1Y2aXR09Z4MjkGl/gE6unonaEZm05fDwyaNI32lXO1mNnZqDg9JHZIOStonaYukpip1d0raL+l5SXdV6L9bUkialW6vTmPukdQt6eqy2pslvZD+3FzrMdjk0NzUmKvdzMZOPa48tgMLImIhcAhoH1ogaQFwG7AEWASsknRpWf88YDnwatndvgEsioiPAOuATan2/cDvAL+YxvsdSefX4TjsDNfW2kLjjIZT2hpnNNDW2jJBMzKbvmoOj4jYFhEn0s0dwNwKZZcBOyPieKp9Blhb1v8wcA8QZeP+JCIGb59X1tcKbI+IH0bEW2ThtaLW47Az35rFc/j82iuY09SIgDlNjXx+7RXeLDebAPV+tdU64MsV2vcDvy9pJlACVgLdkC1PAcWI2CvplDtJ+iTweWA28KupeQ7w/bKyw6ntHSStB9YDzJ8///SOyM4oaxbPcViYnQFGFR6SngYurNC1ISKeSDUbgBPAY0OLIuKApIeAbcDbwB5gQNK5wH1kS1bvEBFbgC2SrgUeAK4bzXzL7r8R2AhQKBRihHIzMxulUYVHRAz7Q1vSLcAqYFnZUtPQMTYDm1P9g2RXDJcAFwODVx1zgeckLYmI18vu+21JH0qb6UXgY2VDzwX+fjTHYWZm9VHzspWkFWT7FUsj4vgwdbMj4qik+WT7HVdFRB/ZktRgzStAISLeSBvqL0VESLoSOAd4E+gCHizbJF9OhU16MzMbO/XY83iE7Af79nT1sCMibpfUDGyKiJWp7vG059EP3JGCYzifAj4jqZ9sn+TT6armh5IeAL6T6n4vIn5Yh+MwM7NRUpVVpimnUChEd3f3RE/DzGzSkLQrIgqV+vwb5mZmlpvDw8zMcnN4mJlZbg4PMzPLzeFhZma5OTzMzCw3h4eZmeXm8DAzs9wcHmZmllu935Ldpqitu4t0dPVypK9Ec1Mjba0tfmt0s2nM4WEj2rq7SHtnD6X+AQCKfSXaO3sAHCBm05SXrWxEHV29J4NjUKl/gI6u3gmakZlNNIeHjehIXylXu5lNfQ4PG1FzU2OudjOb+hweNqK21hYaZzSc0tY4o4G21pYJmpGZTTRvmNuIBjfF/WorMxvk8LBRWbN4jsPCzE6qadlKUoekg5L2SdoiqalK3Z2S9kt6XtJdFfrvlhSSZqXbq9OYeyR1S7o6tX9E0v9N4+yT9Ola5m9mZqen1j2P7cCCiFgIHALahxZIWgDcBiwBFgGrJF1a1j8PWA68Wna3bwCLIuIjwDpgU2o/DnwmIn4eWAH8SbXAMjOzsVNTeETEtog4kW7uAOZWKLsM2BkRx1PtM8Dasv6HgXuAkx+mHhE/iX/5cPXzBvsi4lBEvJC+PgIcBS6o5RjMzCy/er7aah3wVIX2/cA1kmZKOhdYCcyDbHkKKEbE3qF3kvRJSQeBr6exh/YvAc4GXqo2IUnr07JX97Fjx07nmMzMrIIRN8wlPQ1cWKFrQ0Q8kWo2ACeAx4YWRcQBSQ8B24C3gT3AQAqS+8iWrN4hIrYAWyRdCzwAXFc2pw8CfwncHBE/qzb3iNgIbAQoFApRrc7MzPIZMTwi4rrh+iXdAqwClpUtNQ0dYzOwOdU/CBwGLgEuBvZKgmzJ6zlJSyLi9bL7flvShyTNiog3JL2X7GpkQ0TsGMUxmplZndX0Ul1JK8j2K5ZGxPFh6mZHxFFJ88n2O66KiD5gdlnNK0AhBcSlwEsREZKuBM4B3pR0NrAF+IuI+Eotczczs9NX6+95PEL2g317unrYERG3S2oGNkXEylT3uKSZQD9wRwqO4XwK+IykfqAEfDoFya8B1wIz0xUPwC0RsafG4zAzsxxUZaVpyikUCtHd3T3R0zAzmzQk7YqIQqU+v7eVmZnl5vAwM7PcHB5mZpabw8PMzHJzeJiZWW5+S/ZJYOvuoj9Lw8zOKA6PM9zW3UXaO3so9Q8AUOwr0d7ZA+AAMbMJ42WrM1xHV+/J4BhU6h+go6t3gmZkZubwOOMd6SvlajczGw8OjzNcc1NjrnYzs/Hg8DjDtbW20Dij4ZS2xhkNtLW2TNCMzMy8YX7GG9wU96utzOxM4vCYBNYsnuOwMLMzipetzMwsN4eHmZnl5vAwM7PcHB5mZpZbzeEhqUPSQUn7JG2R1FSl7k5J+yU9L+muCv13SwpJs9Lt1WnMPZK6JV09pP69kg5LeqTWYzAzs3zqceWxHVgQEQuBQ0D70AJJC4DbgCXAImCVpEvL+ucBy4FXy+72DWBRRHwEWAdsGjLsA8C36zB/MzPLqebwiIhtEXEi3dwBzK1QdhmwMyKOp9pngLVl/Q8D9wAnP1A9In4S//IB6+eV90n6BeADwLZa529mZvnVe89jHfBUhfb9wDWSZko6F1gJzINseQooRsTeoXeS9ElJB4Gvp7GR9HPAHwGfq/PczcxslEb1S4KSngYurNC1ISKeSDUbgBPAY0OLIuKApIfIrhTeBvYAAylI7iNbsnqHiNgCbJF0Ldky1XXAbwNPRsRhSSPNez2wHmD+/PkjH6iZmY2K/mVlqIZBpFuA3wKWRcTxUdQ/CBwG/oFsb2PwPnOBI8CSiHh9yH2+R7Zn8qfANcDPgHcDZwOPRsS9wz1moVCI7u7uHEdlZja9SdoVEYVKfTW/PYmkFWT7FUuHCw5JsyPiqKT5ZPsdV0VEHzC7rOYVoBARb6QN9ZciIiRdCZwDvBkRN5bV35Lqhw0OMzOrr3q8t9UjZD/Yt6dlpB0RcbukZmBTRKxMdY9Lmgn0A3ek4BjOp4DPSOoHSsCnox6XSWZmVrO6LFtNBl62MjPLZ7hlK/+GuZmZ5ea3ZB/G1t1Ff46GmVkFDo8qtu4u0t7ZQ6l/AIBiX4n2zh4AB4iZTXtetqqio6v3ZHAMKvUP0NHVO0EzMjM7czg8qjjSV8rVbmY2nTg8qmhuaszVbmY2nTg8qmhrbaFxRsMpbY0zGmhrbZmgGZmZnTm8YV7F4Ka4X21lZvZODo9hrFk8x2FhZlaBl63MzCw3h4eZmeXm8DAzs9wcHmZmlpvDw8zMcps2b8ku6Rjwj6d591nAG3WcTr14Xvl4Xvl4XvlMxXn9q4i4oFLHtAmPWkjqrvae9hPJ88rH88rH88pnus3Ly1ZmZpabw8PMzHJzeIzOxomeQBWeVz6eVz6eVz7Tal7e8zAzs9x85WFmZrk5PMzMLDeHRyLp30p6XtLPJBWG9LVLelFSr6TWKve/WNLOVPdlSWePwRy/LGlP+vOKpD1V6l6R1JPquus9jwqP97uSimVzW1mlbkU6hy9Kuncc5tUh6aCkfZK2SGqqUjcu52uk45d0Tvoev5ieSxeN1VzKHnOepG9J+m56/t9ZoeZjkn5U9v29f6znlR532O+LMv8tna99kq4chzm1lJ2HPZJ+LOmuITXjcr4kfVHSUUn7y9reL2m7pBfS3+dXue/NqeYFSTef1gQiwn+yfZ/LgBbg74FCWfvlwF7gHOBi4CWgocL9/w9wQ/r6C8B/GOP5/hFwf5W+V4BZ43jufhf43Ag1DencfQg4O53Ty8d4XsuBs9LXDwEPTdT5Gs3xA78NfCF9fQPw5XH43n0QuDJ9/R7gUIV5fQz42ng9n0b7fQFWAk8BAq4Cdo7z/BqA18l+kW7czxdwLXAlsL+s7Q+Be9PX91Z6zgPvB76X/j4/fX1+3sf3lUcSEQciordC12rgSxHxzxHxMvAisKS8QJKAXwG+kpr+F7BmrOaaHu/XgL8eq8cYA0uAFyPiexHxU+BLZOd2zETEtog4kW7uAOaO5eONYDTHv5rsuQPZc2lZ+l6PmYh4LSKeS1//E3AAmCwfYrMa+IvI7ACaJH1wHB9/GfBSRJzuO1fUJCK+DfxwSHP5c6jaz6FWYHtE/DAi3gK2AyvyPr7DY2RzgO+X3T7MO/9xzQT6yn5QVaqpp2uAH0TEC1X6A9gmaZek9WM4j3KfTUsHX6xyqTya8ziW1pH9L7WS8Thfozn+kzXpufQjsufWuEjLZIuBnRW6f0nSXklPSfr5cZrSSN+XiX5O3UD1/8BNxPkC+EBEvJa+fh34QIWaupy3afVJgpKeBi6s0LUhIp4Y7/lUMso5/jrDX3VcHRFFSbOB7ZIOpv+ljMm8gD8HHiD7x/4A2ZLauloerx7zGjxfkjYAJ4DHqgxT9/M12Uh6N/A4cFdE/HhI93NkSzM/SftZW4EPj8O0ztjvS9rT/ATQXqF7os7XKSIiJI3Z72JMq/CIiOtO425FYF7Z7bmprdybZJfMZ6X/MVaqqcscJZ0FrAV+YZgxiunvo5K2kC2Z1PSPbrTnTtJ/B75WoWs057Hu85J0C7AKWBZpwbfCGHU/XxWM5vgHaw6n7/P7yJ5bY0rSDLLgeCwiOof2l4dJRDwp6VFJsyJiTN8EcBTflzF5To3S9cBzEfGDoR0Tdb6SH0j6YES8lpbwjlaoKZLtywyaS7bXm4uXrUb2VeCG9EqYi8n+B/H/ygvSD6VvAf8mNd0MjNWVzHXAwYg4XKlT0nmS3jP4Ndmm8f5KtfUyZJ35k1Ue7zvAh5W9Ku1sskv+r47xvFYA9wCfiIjjVWrG63yN5vi/Svbcgey59M1qgVcvaU9lM3AgIv64Ss2Fg3svkpaQ/dwY01Ab5fflq8Bn0quurgJ+VLZkM9aqXv1PxPkqU/4cqvZzqAtYLun8tMS8PLXlM9avCJgsf8h+6B0G/hn4AdBV1reB7JUyvcD1Ze1PAs3p6w+RhcqLwN8A54zRPP8ncPuQtmbgybJ57E1/nidbvhnrc/eXQA+wLz15Pzh0Xun2SrJX87w0TvN6kWxtd0/684Wh8xrP81Xp+IHfIws3gHel586L6bn0oXE4R1eTLTfuKztPK4HbB59nwGfTudlL9sKDXx6HeVX8vgyZl4A/S+ezh7JXSY7x3M4jC4P3lbWN+/kiC6/XgP70s+tWsj2ybwAvAE8D70+1BWBT2X3XpefZi8C/P53H99uTmJlZbl62MjOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLLf/D81m18qf8OZTAAAAAElFTkSuQmCC",
+                        "text/plain": [
+                            "<Figure size 432x288 with 1 Axes>"
+                        ]
+                    },
+                    "metadata": {
+                        "needs_background": "light"
+                    },
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "x = 90\n",
+                "plt.scatter(thetas[x : x + 10, 0], thetas[x : x + 10, 1])\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                "data": {
+                    "text/plain": [
+                        "DeviceArray([[-2.9434702 , -1.0610158 , -0.91644555],\n",
+                        "             [-2.9433036 , -1.0609921 , -0.9164234 ],\n",
+                        "             [-2.943137  , -1.0609684 , -0.91640127],\n",
+                        "             [-2.9429703 , -1.0609446 , -0.916379  ],\n",
+                        "             [-2.9428034 , -1.0609208 , -0.91635674],\n",
+                        "             [-2.9426367 , -1.0608972 , -0.91633445],\n",
+                        "             [-2.94247   , -1.0608734 , -0.9163123 ],\n",
+                        "             [-2.9423037 , -1.0608497 , -0.91629004],\n",
+                        "             [-2.942137  , -1.060826  , -0.9162678 ],\n",
+                        "             [-2.9419703 , -1.0608022 , -0.91624564]], dtype=float32)"
+                    ]
+                },
+                "execution_count": 76,
+                "metadata": {},
+                "output_type": "execute_result"
+            }],
+            "source": [
+                "thetas[x : x + 10]\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                "name": "stderr",
+                "output_type": "stream",
+                "text": [
+                    "/Users/alexconstantino/.local/share/virtualenvs/research-pVCP8Qup/lib/python3.8/site-packages/jax/_src/tree_util.py:185: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
+                    "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
+                ]
+            }],
+            "source": [
+                "import numpy as np\n",
+                "import numpyro\n",
+                "import numpyro.distributions as dist\n",
+                "from numpyro.infer import MCMC, NUTS\n",
+                "\n",
+                "\n",
+                "def mcmc_berry_model(y, n):\n",
+                "    mu = numpyro.sample(\"mu\", dist.Normal(-1.34, 10))\n",
+                "    sigma2 = numpyro.sample(\"sigma2\", dist.InverseGamma(0.0005, 0.000005))\n",
+                "    with numpyro.plate(\"j\", 2):\n",
+                "        theta = numpyro.sample(\n",
+                "            \"theta\",\n",
+                "            dist.Normal(mu, jax.numpy.sqrt(sigma2)),\n",
+                "        )\n",
+                "        numpyro.sample(\n",
+                "            \"y\",\n",
+                "            dist.BinomialLogits(theta + (np.log(0.3) - np.log(1 - 0.3)), total_count=n),\n",
+                "            obs=y,\n",
+                "        )\n",
+                "\n",
+                "\n",
+                "def do_mcmc(rng_key, y, n):\n",
+                "    nuts_kernel = NUTS(mcmc_berry_model)\n",
+                "    mcmc = MCMC(\n",
+                "        nuts_kernel,\n",
+                "        progress_bar=False,\n",
+                "        num_warmup=10_000,\n",
+                "        num_samples=1_000_000,\n",
+                "        thinning=10,\n",
+                "    )\n",
+                "    mcmc.run(rng_key, y, n)\n",
+                "    return mcmc.get_samples(group_by_chain=True)\n",
+                "\n",
+                "\n",
+                "s = do_mcmc(jax.random.PRNGKey(0), jnp.array([4, 8]), jnp.array([35, 35]))\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [{
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "[0.06822955]\n",
+                        "(100000,)\n"
+                    ]
+                },
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbsAAAE9CAYAAACSgMzbAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaaklEQVR4nO3df2xV9f3H8deFTiPKr04uNL0NHd4Kpe21wm2p02GwXiotK0E2pNa0BLVb1TTqomM/YOsyZ2fioguQ7TrmWjUiaqRG29I5ZQ5mqRdsHDRuV6Wzt9zVoq2Ak1/l8/2DeL+rSFv6w3v58HwkJO3n3nvu+zbKk3Pv6TkOY4wRAAAWGxPtAQAAGG3EDgBgPWIHALAesQMAWI/YAQCsR+wAANaLi/YAQ3XppZcqOTk52mMAAGJEW1ubDhw48KW3nbOxS05OViAQiPYYAIAY4fV6z3gbb2MCAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrnbPnxsToSl79crRH6KOtqiDaIwA4h7FnBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArMe5MXFOiKVzdXKeTuDcw54dAMB6A8auvb1dCxYs0OzZs5WWlqZHH31UkvTxxx/L5/MpJSVFPp9P3d3dkiRjjCoqKuR2u+XxeLR79+7Itqqrq5WSkqKUlBRVV1dH1nft2qWMjAy53W5VVFTIGDPSrxMAcB4bMHZxcXF6+OGH1draqqamJq1fv16tra2qqqpSbm6ugsGgcnNzVVVVJUmqr69XMBhUMBiU3+9XeXm5pFNxrKys1M6dO9Xc3KzKyspIIMvLy/XYY49FHtfQ0DCKLxkAcL4ZMHYJCQmaM2eOJGn8+PFKTU1VR0eHamtrVVpaKkkqLS3Vli1bJEm1tbUqKSmRw+FQTk6Oenp6FA6HtXXrVvl8PsXHx2vy5Mny+XxqaGhQOBzWwYMHlZOTI4fDoZKSksi2AAAYCWd1gEpbW5veeustzZs3T52dnUpISJAkTZs2TZ2dnZKkjo4OJSUlRR7jcrnU0dHR77rL5Tpt/cv4/X75/X5JUldX19mMDgA4jw36AJXDhw9r2bJleuSRRzRhwoQ+tzkcDjkcjhEf7ovKysoUCAQUCAQ0ZcqUUX8+AIAdBhW748ePa9myZSouLtaNN94oSZo6darC4bAkKRwOy+l0SpISExPV3t4eeWwoFFJiYmK/66FQ6LR1AABGyoCxM8bo1ltvVWpqqu69997IemFhYeSIyurqai1ZsiSyXlNTI2OMmpqaNHHiRCUkJCgvL0+NjY3q7u5Wd3e3GhsblZeXp4SEBE2YMEFNTU0yxqimpiayLQAARsKAn9nt2LFDTzzxhDIyMpSZmSlJ+tWvfqXVq1dr+fLl2rhxo6ZPn67NmzdLkvLz81VXVye3261x48bp8ccflyTFx8drzZo1ysrKkiStXbtW8fHxkqQNGzZo5cqV+uyzz7Ro0SItWrRoNF4rAOA85TDn6C+1eb1eBQKBaI9hrVg6Y0ms4QwqQGzqrwucQQUAYD1iBwCwHieCjiG8dQgAo4M9OwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArBcX7QGiKXn1y9EeAQDwFWDPDgBgPWIHALAesQMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHrEDgBgPWIHALAesQMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHrEDgBgvQFjt2rVKjmdTqWnp0fWfv7znysxMVGZmZnKzMxUXV1d5LYHH3xQbrdbM2fO1NatWyPrDQ0Nmjlzptxut6qqqiLr+/bt07x58+R2u3XTTTfp2LFjI/XaAACQNIjYrVy5Ug0NDaet33PPPWppaVFLS4vy8/MlSa2trdq0aZP27t2rhoYG3XHHHert7VVvb6/uvPNO1dfXq7W1VU8//bRaW1slST/84Q91zz336N1339XkyZO1cePGEX6JAIDz3YCxmz9/vuLj4we1sdraWq1YsUIXXnihvvGNb8jtdqu5uVnNzc1yu92aMWOGLrjgAq1YsUK1tbUyxujVV1/Vd77zHUlSaWmptmzZMqwXBADAFw35M7t169bJ4/Fo1apV6u7uliR1dHQoKSkpch+Xy6WOjo4zrn/00UeaNGmS4uLi+qwDADCShhS78vJyvffee2ppaVFCQoJ+8IMfjPRcX8rv98vr9crr9aqrq+sreU4AwLlvSLGbOnWqxo4dqzFjxuj2229Xc3OzJCkxMVHt7e2R+4VCISUmJp5x/etf/7p6enp04sSJPutnUlZWpkAgoEAgoClTpgxldADAeWhIsQuHw5GvX3jhhciRmoWFhdq0aZOOHj2qffv2KRgMKjs7W1lZWQoGg9q3b5+OHTumTZs2qbCwUA6HQwsWLNBzzz0nSaqurtaSJUtG4GUBAPD/4ga6Q1FRkbZt26YDBw7I5XKpsrJS27ZtU0tLixwOh5KTk/X73/9ekpSWlqbly5dr9uzZiouL0/r16zV27FhJpz7jy8vLU29vr1atWqW0tDRJ0q9//WutWLFCP/3pT3XllVfq1ltvHcWXCwA4HzmMMSbaQwyF1+tVIBAY1jaSV788QtPgfNJWVRDtEQB8if66wBlUAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFhvwIu3Augr1q6DyPX1gIGxZwcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKw3YOxWrVolp9Op9PT0yNrHH38sn8+nlJQU+Xw+dXd3S5KMMaqoqJDb7ZbH49Hu3bsjj6murlZKSopSUlJUXV0dWd+1a5cyMjLkdrtVUVEhY8xIvj4AAAaO3cqVK9XQ0NBnraqqSrm5uQoGg8rNzVVVVZUkqb6+XsFgUMFgUH6/X+Xl5ZJOxbGyslI7d+5Uc3OzKisrI4EsLy/XY489FnncF58LAIDhGjB28+fPV3x8fJ+12tpalZaWSpJKS0u1ZcuWyHpJSYkcDodycnLU09OjcDisrVu3yufzKT4+XpMnT5bP51NDQ4PC4bAOHjyonJwcORwOlZSURLYFAMBIGdJndp2dnUpISJAkTZs2TZ2dnZKkjo4OJSUlRe7ncrnU0dHR77rL5TptHQCAkRQ33A04HA45HI6RmGVAfr9ffr9fktTV1fWVPCcA4Nw3pD27qVOnKhwOS5LC4bCcTqckKTExUe3t7ZH7hUIhJSYm9rseCoVOWz+TsrIyBQIBBQIBTZkyZSijAwDOQ0OKXWFhYeSIyurqai1ZsiSyXlNTI2OMmpqaNHHiRCUkJCgvL0+NjY3q7u5Wd3e3GhsblZeXp4SEBE2YMEFNTU0yxqimpiayLQAARsqAb2MWFRVp27ZtOnDggFwulyorK7V69WotX75cGzdu1PTp07V582ZJUn5+vurq6uR2uzVu3Dg9/vjjkqT4+HitWbNGWVlZkqS1a9dGDnrZsGGDVq5cqc8++0yLFi3SokWLRuu1AgDOUw5zjv5im9frVSAQGNY2kle/PELTANHTVlUQ7RGAmNBfFziDCgDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKwXF+0BAAxP8uqXoz1CH21VBdEeATgNe3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFhvWLFLTk5WRkaGMjMz5fV6JUkff/yxfD6fUlJS5PP51N3dLUkyxqiiokJut1sej0e7d++ObKe6ulopKSlKSUlRdXX1cEYCAOA0w96ze+2119TS0qJAICBJqqqqUm5uroLBoHJzc1VVVSVJqq+vVzAYVDAYlN/vV3l5uaRTcaysrNTOnTvV3NysysrKSCABABgJI/42Zm1trUpLSyVJpaWl2rJlS2S9pKREDodDOTk56unpUTgc1tatW+Xz+RQfH6/JkyfL5/OpoaFhpMcCAJzHhhU7h8OhhQsXau7cufL7/ZKkzs5OJSQkSJKmTZumzs5OSVJHR4eSkpIij3W5XOro6Djj+pfx+/3yer3yer3q6uoazugAgPPIsE4Xtn37diUmJurDDz+Uz+fTrFmz+tzucDjkcDiGNeD/KisrU1lZmSRFPiMEAGAgw9qzS0xMlCQ5nU4tXbpUzc3Nmjp1qsLhsCQpHA7L6XRG7tve3h55bCgUUmJi4hnXAQAYKUOO3aeffqpDhw5Fvm5sbFR6eroKCwsjR1RWV1dryZIlkqTCwkLV1NTIGKOmpiZNnDhRCQkJysvLU2Njo7q7u9Xd3a3Gxkbl5eWNwEsDAOCUIb+N2dnZqaVLl0qSTpw4oZtvvlk33HCDsrKytHz5cm3cuFHTp0/X5s2bJUn5+fmqq6uT2+3WuHHj9Pjjj0uS4uPjtWbNGmVlZUmS1q5dq/j4+OG+LgAAIhzGGBPtIYbC6/VGft1hqGLt0iiADbjED6Klvy5wBhUAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1ouL9gAA7JK8+uVojxDRVlUQ7REQI9izAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB4XbwVgrVi6kKzExWSjiT07AID1iB0AwHoxE7uGhgbNnDlTbrdbVVVV0R4HAGCRmIhdb2+v7rzzTtXX16u1tVVPP/20Wltboz0WAMASMRG75uZmud1uzZgxQxdccIFWrFih2traaI8FALBETByN2dHRoaSkpMj3LpdLO3fujOJEADDyYuno0PPtyNCYiN1g+f1++f1+SdI777wjr9c7rO1dOsTHdXV1acqUKcN67q8S844u5h1dzDs6vN6fSTp35v1cf/O2tbWd8XExEbvExES1t7dHvg+FQkpMTDztfmVlZSorK/sqR/tSXq9XgUAg2mMMGvOOLuYdXcw7us6XeWPiM7usrCwFg0Ht27dPx44d06ZNm1RYWBjtsQAAloiJPbu4uDitW7dOeXl56u3t1apVq5SWlhbtsQAAloiJ2ElSfn6+8vPzoz3GoMTCW6lng3lHF/OOLuYdXefLvA5jjBnhWQAAiCkx8ZkdAACjidgN0Zo1a+TxeJSZmamFCxdq//790R6pX/fdd59mzZolj8ejpUuXqqenJ9oj9evZZ59VWlqaxowZE9NHip1Lp7lbtWqVnE6n0tPToz3KoLS3t2vBggWaPXu20tLS9Oijj0Z7pH4dOXJE2dnZuuKKK5SWlqaf/exn0R5pUHp7e3XllVdq8eLF0R5lQMnJycrIyFBmZubZ/+qZwZB88sknka8fffRR873vfS+K0wxs69at5vjx48YYY+6//35z//33R3mi/rW2tpp33nnHXHvttebNN9+M9jhf6sSJE2bGjBnmvffeM0ePHjUej8fs3bs32mOd0V//+leza9cuk5aWFu1RBmX//v1m165dxhhjDh48aFJSUmL653vy5Elz6NAhY4wxx44dM9nZ2eaNN96I8lQDe/jhh01RUZEpKCiI9igDmj59uunq6hrSY9mzG6IJEyZEvv7000/lcDiiOM3AFi5cqLi4U8cj5eTkKBQKRXmi/qWmpmrmzJnRHqNf59pp7ubPn6/4+PhojzFoCQkJmjNnjiRp/PjxSk1NVUdHR5SnOjOHw6FLLrlEknT8+HEdP3485v9eCIVCevnll3XbbbdFe5RRR+yG4Sc/+YmSkpL01FNP6Re/+EW0xxm0P/7xj1q0aFG0xzjnfdlp7mL5L+NzWVtbm9566y3Nmzcv2qP0q7e3V5mZmXI6nfL5fDE/7913362HHnpIY8acGylwOBxauHCh5s6dGzmb1mCdG68wSq6//nqlp6ef9ufzf70/8MADam9vV3FxsdatWxflaQeeVzo1c1xcnIqLi6M46SmDmRc4fPiwli1bpkceeaTPOyqxaOzYsWppaVEoFFJzc7P27NkT7ZHO6KWXXpLT6dTcuXOjPcqgbd++Xbt371Z9fb3Wr1+v119/fdCPjZnfs4tFr7zyyqDuV1xcrPz8fFVWVo7yRP0baN4//elPeumll/SXv/wlJt5eGezPN1YN9jR3GLrjx49r2bJlKi4u1o033hjtcQZt0qRJWrBggRoaGmL2gKAdO3boxRdfVF1dnY4cOaKDBw/qlltu0ZNPPhnt0c7o8/+/nE6nli5dqubmZs2fP39Qj2XPboiCwWDk69raWs2aNSuK0wysoaFBDz30kF588UWNGzcu2uNYgdPcjS5jjG699Valpqbq3nvvjfY4A+rq6ooc5fzZZ5/pz3/+c0z/vfDggw8qFAqpra1NmzZt0nXXXRfTofv000916NChyNeNjY1n9Q8JYjdEq1evVnp6ujwejxobG2P+sOi77rpLhw4dks/nU2Zmpr7//e9He6R+vfDCC3K5XHrjjTdUUFCgvLy8aI90mv89zV1qaqqWL18e06e5Kyoq0lVXXaV//vOfcrlc2rhxY7RH6teOHTv0xBNP6NVXX1VmZqYyMzNVV1cX7bHOKBwOa8GCBfJ4PMrKypLP5zsnDuc/V3R2duqaa67RFVdcoezsbBUUFOiGG24Y9OM5gwoAwHrs2QEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4YhM/PeTgU69atk9vtlsPh0IEDByLrxhhVVFTI7XbL4/Fo9+7dkdvC4fCAh61/85vfHPJMZ+PEiRMqKCjQpZdeetoZQc50NY1//OMfWrly5VcyHzAYxA4YZVdffbVeeeUVTZ8+vc96fX29gsGggsGg/H6/ysvLI7f95je/0e23397vdv/+97+PyrxfVF5erlmzZmnLli266aab+pxE3Ofzac+ePXr77bd1+eWX68EHH5QkZWRkKBQK6YMPPvhKZgQGQuyAs2CM0X333af09HRlZGTomWeekSSdPHlSd9xxh2bNmiWfz6f8/Hw999xzkqQrr7xSycnJp22rtrZWJSUlcjgcysnJUU9Pj8LhsCTp+eefj/zC7N69e5Wdna3MzEx5PJ7I2Xs+39vs77mTk5P1ox/9KHL9r927dysvL0+XXXaZfve730k6de7J3NxczZkzRxkZGX3OTVpZWamJEyfq4Ycf1jXXXKM//OEPKioq0ieffCKp/6tpfPvb39amTZtG5gcPDNfIXWkIsNfFF19sjDHmueeeM9dff705ceKE+c9//mOSkpLM/v37zbPPPmsWLVpkent7TTgcNpMmTTLPPvtsn2188VpcBQUF5m9/+1vk++uuu868+eab5v333zdz5syJrN91113mySefNMYYc/ToUfPf//63z0z9Pff06dPNhg0bjDHG3H333SYjI8McPHjQfPjhh8bpdBpjjDl+/Hjk+oxdXV3msssuMydPnjzrn9HixYvNE088Efl++/btZvHixWe9HWA0cCJo4Cxs375dRUVFGjt2rKZOnaprr71Wb775prZv367vfve7GjNmjKZNm6YFCxYM+TnC4bCmTJkS+f6qq67SAw88oFAopBtvvFEpKSmnzdTfc39+vs6MjAwdPnxY48eP1/jx43XhhReqp6dHF198sX784x/r9ddf15gxY9TR0aHOzk5NmzZt0DN/2dU0nE6n9u/fP5QfATDieBsTiJIzXTXhoosu0pEjRyLrN998s1588UVddNFFys/P16uvvnpWz3PhhRdKksaMGRP5+vPvT5w4oaeeekpdXV3atWuXWlpaNHXq1D7PP5DPr6bx1FNP9bmaxpEjR3TRRRed1azAaCF2wFn41re+pWeeeUa9vb3q6urS66+/ruzsbF199dV6/vnndfLkSXV2dmrbtm0DbquwsFA1NTUyxqipqUkTJ05UQkKCLr/8crW1tUXu9/7772vGjBmqqKjQkiVL9Pbbb/fZzlCe+3998skncjqd+trXvqbXXntN//73vwf92P6upvGvf/0rZi9vg/MPsQPOwtKlS+XxeHTFFVfouuuu00MPPaRp06Zp2bJlcrlcmj17tm655RbNmTNHEydOlCT99re/lcvlUigUksfj0W233SZJys/P14wZM+R2u3X77bdrw4YNkqSLL75Yl112md59911J0ubNm5Wenq7MzEzt2bNHJSUlfWbq77kHo7i4WIFAQBkZGaqpqTmry9L0dzWN1157TQUFBYPeFjCauOoBMEIOHz6sSy65RB999JGys7O1Y8eOs/rc63+98MIL2rVrl375y19+5c89Eo4ePaprr71W27dvjxytCUQT/xUCI2Tx4sXq6enRsWPHtGbNmmHFZunSpfroo4+i8twj4YMPPlBVVRWhQ8xgzw4AYD0+swMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHr/B6De37a9tSTBAAAAAElFTkSuQmCC",
+                        "text/plain": [
+                            "<Figure size 504x360 with 1 Axes>"
+                        ]
+                    },
+                    "metadata": {},
+                    "output_type": "display_data"
+                }
+            ],
+            "source": [
+                "sig = s[\"sigma2\"]\n",
+                "# sig = sig[np.newaxis]\n",
+                "sig = sig[:, :][0]\n",
+                "print(np.quantile(sig, [0.5]))\n",
+                "sig = np.log10(sig)\n",
+                "print(sig.shape)\n",
+                "fig = plt.figure(figsize=(7, 5))\n",
+                "plt.hist(sig, bins=10)\n",
+                "plt.xlabel(\"log10(sigma^2)\")\n",
+                "fig.patch.set_alpha(1)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "def jax_calc_posterior_and_exceedances(\n",
+                "    theta_max,\n",
+                "    y,\n",
+                "    n,\n",
+                "    log_prior,\n",
+                "    neg_precQ,\n",
+                "    logprecQdet,\n",
+                "    hess_inv,\n",
+                "    sigma2_wts,\n",
+                "    logit_p1,\n",
+                "    mu_0,\n",
+                "    thresh_theta,\n",
+                "):\n",
+                "    theta_m0 = theta_max - mu_0\n",
+                "    theta_adj = theta_max + logit_p1\n",
+                "    exp_theta_adj = jnp.exp(theta_adj)\n",
+                "    logjoint = (\n",
+                "        0.5 * jnp.einsum(\"...i,...ij,...j\", theta_m0, neg_precQ, theta_m0)\n",
+                "        + logprecQdet\n",
+                "        + jnp.sum(\n",
+                "            theta_adj * y[:, None] - n[:, None] * jnp.log(exp_theta_adj + 1),\n",
+                "            axis=-1,\n",
+                "        )\n",
+                "        + log_prior\n",
+                "    )\n",
+                "\n",
+                "    log_sigma2_post = logjoint + 0.5 * jnp.log(jnp.linalg.det(-hess_inv))\n",
+                "    sigma2_post = jnp.exp(log_sigma2_post)\n",
+                "    sigma2_post /= jnp.sum(sigma2_post * sigma2_wts, axis=1)[:, None]\n",
+                "\n",
+                "    theta_sigma = jnp.sqrt(jnp.diagonal(-hess_inv, axis1=2, axis2=3))\n",
+                "    exc_sigma2 = 1.0 - jax.scipy.stats.norm.cdf(\n",
+                "        thresh_theta,\n",
+                "        theta_max,\n",
+                "        theta_sigma,\n",
+                "    )\n",
+                "    exceedances = jnp.sum(\n",
+                "        exc_sigma2 * sigma2_post[:, :, None] * sigma2_wts[None, :, None], axis=1\n",
+                "    )\n",
+                "    return sigma2_post, exceedances\n"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3.10.5 ('kevlar')",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.5"
+        },
+        "orig_nbformat": 4,
+        "vscode": {
+            "interpreter": {
+                "hash": "b6bd0657068c38953c2fe5251f8f61893d47205eb021f5d049a4c9233ce79361"
+            }
+        }
     },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 160,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "import berrylib.fast_inla\n",
-    "import importlib\n",
-    "from functools import partial\n",
-    "\n",
-    "importlib.reload(berrylib.fast_inla)\n",
-    "from berrylib.fast_inla import FastINLA, jax_opt\n",
-    "\n",
-    "# assert jax.config.read(\"jax_enable_x64\")\n",
-    "\n",
-    "fi = FastINLA(n_arms=2)\n",
-    "# sigma2 = jnp.array(1e5)\n",
-    "# y = jnp.array([0, 0, 30, 30])[jnp.newaxis]\n",
-    "# n = jnp.array([30, 30, 30, 30])[jnp.newaxis]\n",
-    "# # fi.jax_inference(y, n)\n",
-    "\n",
-    "\n",
-    "def jax_faster_invert(D, S):\n",
-    "    \"\"\"Compute the inverse of a diagonal matrix D plus a shift S.\n",
-    "\n",
-    "    This function uses \"Sherman-Morrison\" formula:\n",
-    "    https://en.wikipedia.org/wiki/Sherman–Morrison_formula\n",
-    "    \"\"\"\n",
-    "    D_inverse = 1.0 / D\n",
-    "    multiplier = -S / (1 + S * D_inverse.sum())\n",
-    "    M = multiplier * jnp.outer(D_inverse, D_inverse)\n",
-    "    M = M + jnp.diag(D_inverse)\n",
-    "    return M\n",
-    "\n",
-    "\n",
-    "# @jax.jit\n",
-    "def jax_opt(y, neg_precQ, fast_loop=True):\n",
-    "    # y = jnp.array([29.65146991, 27.51985572])\n",
-    "    n = jnp.array([35, 35])\n",
-    "    # neg_precQ = jnp.array([[-28764.0366170816, 28764.031617082037], [28764.031617082037, -28764.0366170816]])\n",
-    "    logit_p1 = -0.8472978603872036\n",
-    "    mu_0 = -1.34\n",
-    "    tol = 0.001\n",
-    "\n",
-    "    def step(args):\n",
-    "        i, theta_max, hess_inv, go = args\n",
-    "        theta_m0 = theta_max - mu_0\n",
-    "        exp_theta_adj = jnp.exp(theta_max + logit_p1)\n",
-    "        nCeta = jnp.log(n) - jnp.log1p(exp_theta_adj) + (theta_max + logit_p1)\n",
-    "        diag = jnp.exp(nCeta - jnp.log1p(exp_theta_adj))\n",
-    "        nCeta = jnp.exp(nCeta)\n",
-    "\n",
-    "        grad = neg_precQ @ theta_m0 + y - nCeta\n",
-    "\n",
-    "        shift = neg_precQ[..., 0, 1]\n",
-    "        prec_d = jnp.diag(neg_precQ) - shift\n",
-    "        diag = prec_d - diag\n",
-    "\n",
-    "        # Apply the regularization suggested in: https://arxiv.org/abs/2112.02089\n",
-    "        H = 10\n",
-    "        reg = jnp.sqrt(H * jnp.linalg.norm(grad))\n",
-    "        diag += reg\n",
-    "\n",
-    "        hess_inv = jax_faster_invert(diag, shift)\n",
-    "        step = -hess_inv.dot(grad)\n",
-    "\n",
-    "        probit_step = 1 / (1 + jnp.exp(-theta_max))\n",
-    "        probit_step = probit_step * (1 - probit_step) * step\n",
-    "        go = jnp.max(jnp.abs(probit_step)) > tol\n",
-    "        # go = jnp.sum(step**2) > tol**2\n",
-    "        return i + 1, theta_max + step, hess_inv, go\n",
-    "\n",
-    "    n_arms = y.shape[0]\n",
-    "    theta_max0 = jnp.zeros(n_arms)\n",
-    "    init_args = (0, theta_max0, jnp.zeros((n_arms, n_arms)),  True)\n",
-    "    max_iter = 1000\n",
-    "\n",
-    "    if fast_loop:\n",
-    "        out = jax.lax.while_loop( lambda args: ((args[0] < max_iter) & args[-1]), step, init_args)\n",
-    "    else:\n",
-    "        args = init_args\n",
-    "        step = jax.jit(step)\n",
-    "        converged = False\n",
-    "        for i in range(max_iter):\n",
-    "            args = step(args)\n",
-    "            out = args\n",
-    "            if not args[-1]:\n",
-    "                converged = True\n",
-    "                break\n",
-    "    i, theta_max, hess_inv, go = out\n",
-    "    return theta_max, hess_inv\n",
-    "\n",
-    "\n",
-    "# def run(y, i):\n",
-    "#     # cov = jnp.full((fi.n_arms, fi.n_arms), fi.mu_sig_sq)\n",
-    "#     # cov = cov + jnp.diag(jnp.full(fi.n_arms, sigma2))\n",
-    "#     # # shift, prec_d = berrylib.fast_inla.jax_faster_invert(jnp.repeat(sigma2, arms), 100)\n",
-    "#     # # neg_precQ = -(jnp.diag(prec_d) + shift)\n",
-    "#     # neg_precQ = jnp.linalg.inv(cov)\n",
-    "#     n = np.array([[35, 35]])\n",
-    "\n",
-    "#     with open(\"out.txt\", \"a\") as f:\n",
-    "#         def p(x):\n",
-    "#             f.write(str(x) + \"\\n\")\n",
-    "#         p(y)\n",
-    "#         f.flush()\n",
-    "#     opt = jax_opt\n",
-    "#     theta_max, hess_inv = opt(\n",
-    "#     y[0],\n",
-    "#     n[0],\n",
-    "#     # fi.cov,\n",
-    "#     fi.neg_precQ[i],\n",
-    "#     # None,\n",
-    "#     fi.logit_p1,\n",
-    "#     fi.mu_0,\n",
-    "#     fi.tol,\n",
-    "#     )\n",
-    "#     if np.isnan(theta_max).any():\n",
-    "#         assert False, (y)\n",
-    "#     return theta_max\n",
-    "\n",
-    "trials = 100_000\n",
-    "\n",
-    "acc = 0\n",
-    "def test(y, j, fn=jax_opt):\n",
-    "    global acc\n",
-    "    if not fn(y, fi.neg_precQ[j]):\n",
-    "        acc +=1 #(i, y, j)\n",
-    "\n",
-    "# y = jnp.array([ 7.28087852, 19.92078862])\n",
-    "# j = 0\n",
-    "# test(y, j, fn=partial(jax_opt, fast_loop=False))\n",
-    "\n",
-    "fn = jax.jit(jax_opt)\n",
-    "acc = 0\n",
-    "for i in range(trials):\n",
-    "    arms = 2\n",
-    "    y = np.random.uniform(0, 35, size=(arms))\n",
-    "    if i % (trials // 10) == 0:\n",
-    "        print(i)\n",
-    "    for j in range(15):\n",
-    "        test(y, j, fn=fn)\n",
-    "# # %timeit run()\n",
-    "# _, exc, _, _ = fi.jax_inference(Y_I2, N_I2)\n",
-    "# exc[-1]\n",
-    "# ret = fi.jax_inference(Y_I2, N_I2)\n",
-    "# sigma2_post, exceedances, theta_max, theta_sigma=ret\n",
-    "# for r in ret:\n",
-    "# print(r.dtype)\n",
-    "# theta_max = jnp.array([0.1, 0.1, 0.1, 0.1])\n",
-    "# theta_m0 = theta_max - fi.mu_0\n",
-    "# theta_adj = theta_max + fi.logit_p1\n",
-    "# exp_theta_adj = jnp.exp(theta_adj)\n",
-    "# y = Y_I2\n",
-    "# n = N_I2\n",
-    "\n",
-    "# jax_opt()\n",
-    "acc\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 164,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(array([[ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-       "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-       "        [ 0.,  0., -1., ...,  1.,  1.,  1.],\n",
-       "        ...,\n",
-       "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
-       "        [ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
-       "        [ 1.,  1.,  1., ...,  1.,  1.,  1.]]),\n",
-       " array([[        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-       "           8.5175151 ,   8.87252596],\n",
-       "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-       "           8.5175151 ,   8.87252596],\n",
-       "        [        -inf,         -inf,  -7.11662666, ...,   6.93373191,\n",
-       "           8.5175151 ,   8.87252596],\n",
-       "        ...,\n",
-       "        [-15.78124253, -15.25253092, -14.32642149, ...,   1.32578601,\n",
-       "           2.18722541,   2.42099027],\n",
-       "        [-15.81360094, -15.28283245, -14.3575988 , ...,  -2.60645969,\n",
-       "          -2.60283052,  -2.60188043],\n",
-       "        [-15.83460559, -15.30497092, -14.383241  , ...,  -3.23427153,\n",
-       "          -3.23251662,  -3.23205077]]))"
-      ]
-     },
-     "execution_count": 164,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "with open(\"/home/const/kevlar/out.txt\") as f:\n",
-    "    arr = np.array(eval(f.read()))\n",
-    "arr.shape\n",
-    "np.linalg.slogdet(arr)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0010487821918949499\n",
-      "[0.00074172 0.00074148]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# with jit:\n",
-    "x = np.array([2.3373992443084717, 2.337362289428711])\n",
-    "y = np.array([2.3381409645080566, 2.338103771209717])\n",
-    "\n",
-    "def \n",
-    "\n",
-    "# without jit:\n",
-    "# [2.3373985290527344, 2.3373618125915527]\n",
-    "print(np.linalg.norm(x - y))\n",
-    "print(np.abs(x-y))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[-6.37561     0.02439026  0.02439024  0.02439024]\n",
-      " [ 0.02439026 -6.37561     0.02439026  0.02439025]\n",
-      " [ 0.02439025  0.02439026 -6.37561     0.02439024]\n",
-      " [ 0.02439025  0.02439025  0.02439024 -6.37561   ]]\n",
-      "[[-0.1568547  -0.00060468 -0.00060468 -0.00060468]\n",
-      " [-0.00060468 -0.15685467 -0.00060468 -0.00060468]\n",
-      " [-0.00060468 -0.00060468 -0.15685469 -0.00060468]\n",
-      " [-0.00060468 -0.00060468 -0.00060468 -0.15685469]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "def logit(x):\n",
-    "    return jnp.log(x) - jnp.log(1 - x)\n",
-    "\n",
-    "\n",
-    "def get_log_berry_likelihood(y, n):\n",
-    "    def log_berry_likelihood(theta, sigma_sq):\n",
-    "        ll = 0.0\n",
-    "        ll += dist.InverseGamma(0.0005, 0.000005).log_prob(sigma_sq)\n",
-    "        cov = jnp.full((4, 4), 100) + jnp.diag(jnp.repeat(sigma_sq, 4))\n",
-    "        ll += (\n",
-    "            dist.MultivariateNormal(-1.34, covariance_matrix=cov).log_prob(theta).sum()\n",
-    "        )\n",
-    "        ll += dist.BinomialLogits(logit(0.3) + theta, total_count=n).log_prob(y).sum()\n",
-    "        return ll\n",
-    "\n",
-    "    return log_berry_likelihood\n",
-    "\n",
-    "\n",
-    "ll = get_log_berry_likelihood(y, n)\n",
-    "theta = jnp.array([0.0, 0, 0, 0])\n",
-    "sigma_sq = 1e1\n",
-    "ll(theta, sigma_sq)\n",
-    "grad = jax.grad(ll, 0)\n",
-    "hess = jax.jacobian(grad)\n",
-    "h = hess(theta, sigma_sq)\n",
-    "print(h)\n",
-    "print(jnp.linalg.inv(h))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def mcmc_berry_model(y, n):\n",
-    "    # y, n = data\n",
-    "    mu = numpyro.sample(\"mu\", dist.Normal(-1.34, 10))\n",
-    "    sigma2 = numpyro.sample(\"sigma2\", dist.InverseGamma(0.0005, 0.000005))\n",
-    "    with numpyro.plate(\"j\", 4):\n",
-    "        theta = numpyro.sample(\n",
-    "            \"theta\",\n",
-    "            dist.Normal(mu, jax.numpy.sqrt(sigma2)),\n",
-    "        )\n",
-    "        numpyro.sample(\n",
-    "            \"y\",\n",
-    "            dist.BinomialLogits(theta + 0, total_count=n),\n",
-    "            obs=y,\n",
-    "        )\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Stochastic Variational Inference"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 3000/3000 [00:02<00:00, 1104.55it/s, init loss: 78.8034, avg. loss [2851-3000]: 19.7578]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpyro\n",
-    "from functools import partial\n",
-    "from numpyro.infer import Predictive, SVI, Trace_ELBO, init_to_uniform\n",
-    "from numpyro.contrib.einstein import RBFKernel, SteinVI\n",
-    "from numpyro.infer.autoguide import (\n",
-    "    AutoLaplaceApproximation,\n",
-    "    AutoDelta,\n",
-    "    AutoMultivariateNormal,\n",
-    "    AutoBNAFNormal,\n",
-    ")\n",
-    "\n",
-    "data = Y_I2[-1], N_I2[-1]\n",
-    "y, n = data\n",
-    "model = mcmc_berry_model\n",
-    "optimizer = numpyro.optim.Adam(step_size=0.005)\n",
-    "# guide = AutoLaplaceApproximation(model)\n",
-    "guide = AutoBNAFNormal(model)\n",
-    "# guide = AutoMultivariateNormal(model)\n",
-    "# guide = AutoDelta(model, init_loc_fn=partial(init_to_uniform, radius=0.1))\n",
-    "svi = SVI(model, guide, optimizer, loss=Trace_ELBO())\n",
-    "svi_result = svi.run(jax.random.PRNGKey(0), 3_000, y, n)\n",
-    "params = svi_result.params\n",
-    "predictive = Predictive(guide, params=params, num_samples=100000)\n",
-    "samples = predictive(jax.random.PRNGKey(1), data)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x14dc2b910>]"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAtg0lEQVR4nO3dd3wUZf4H8M83jYRQQwIiAUIVUYoYmiDSRAR7O+uBxx131tP7WSge6N2p6Hm2O1E5y6GiooiHJ0gVBASB0DuEahBSIEAghLTv74+d3WwvyW52J/m8X6+8sjM7O/udnd3vPPPM8zwjqgoiIjKfqHAHQERElcMETkRkUkzgREQmxQRORGRSTOBERCYVU51vlpycrGlpadX5lkREprd+/fo8VU1xnl+tCTwtLQ0ZGRnV+ZZERKYnIofczWcVChGRSfmVwEXkcRHZLiLbROQzEYkXkTYiskZEMkVkpojEhTpYIiKq4DOBi0gLAI8CSFfVSwFEA7gTwEsAXlPV9gDyAYwJZaBEROTI3yqUGAAJIhIDoC6AowAGA5hlPD8dwE1Bj46IiDzymcBV9QiAVwAchiVxnwKwHsBJVS01FssC0MLd60VkrIhkiEhGbm5ucKImIiK/qlAaA7gRQBsAFwJIBDDc3zdQ1Wmqmq6q6SkpLq1giIiokvypQhkK4ICq5qpqCYDZAPoBaGRUqQBAKoAjIYqRiIjc8CeBHwbQR0TqiogAGAJgB4ClAG4zlhkFYE5oQgRmb8jCjDVum0ESEdVa/tSBr4HlYuUGAFuN10wD8DSAP4lIJoAmAN4PVZDfbP4FM9f9HKrVExGZkl89MVV1MoDJTrP3A+gV9IjckOp4EyIikzFNT0zeOIiIyJEpEriIQMEMTkRkzxwJHCyBExE5M0cCZyU4EZELUyRwgCVwIiJnJkngwhpwIiInpkjgIoCyCE5E5MAcCTzcARARRSBzJHBmcCIiF6ZI4AAvYhIROTNFAhewIw8RkTNzJHBhCZyIyJlpEjgRETkyRQIHwAoUIiInpkjgAmE7cCIiJ6ZI4BCWwImInJkigbMKnIjIlSkSOAAWwYmInJgigVtu6EBERPbMkcDBwayIiJyZI4HzIiYRkQtzJPBwB0BEFIFMkcABdqUnInLmM4GLyEUissnu77SIPCYiSSKySET2Gv8bhypI3pWeiMiVzwSuqrtVtbuqdgdwOYBCAF8DGAdgiap2ALDEmA4J3pWeiMhVoFUoQwDsU9VDAG4EMN2YPx3ATUGMyxErwYmIXASawO8E8JnxuJmqHjUeHwPQzN0LRGSsiGSISEZubm4lw2QJnIjImd8JXETiANwA4Evn59TSSNttilXVaaqarqrpKSkplQpSWAQnInIRSAn8WgAbVDXbmM4WkeYAYPzPCXZwVrwrPRGRq0AS+F2oqD4BgG8AjDIejwIwJ1hBOWP5m4jIlV8JXEQSAVwNYLbd7CkArhaRvQCGGtMh88upIoz+cC1L4kREhhh/FlLVswCaOM07DkurlJCz3lJt2e5clJQp4mJYJiciMkVPTF7EJCJyZY4Ebpe/2SOTiMjCdAmciIgsTJHA7fEaJhGRhUkSOIvgRETOTJHAHerAWQInIgJglgRu95gXMYmILEyRwO2xBE5EZGGKBO7YjJCIiACzJHC7ShR2pScisjBHAmcJnIjIhSkSuD0WwImILEyRwB1agTOBExEBMEsCt6tDYTNCIiILUyRwe2eLy8IdAhFRRDBdAu835ftwh0BEFBFMkcA5GiERkStzJHAOZkVE5MIcCZz5m4jIhTkSeLgDICKKQKZI4ERE5MoUCdy5CmXulqPhCYSIKIL4lcBFpJGIzBKRXSKyU0T6ikiSiCwSkb3G/8ahClKcMvhL83eF6q2IiEzD3xL4GwDmq2onAN0A7AQwDsASVe0AYIkxHRKsAycicuUzgYtIQwADALwPAKparKonAdwIYLqx2HQAN4UmRCIicsefEngbALkAPhSRjSLynogkAmimqtbK6GMAmrl7sYiMFZEMEcnIzc2tXJQsghMRufAngccA6AHgbVW9DMBZOFWXqOUuC25HmVLVaaqarqrpKSkplQqSHXmIiFz5k8CzAGSp6hpjehYsCT1bRJoDgPE/JzQhsiMPEZE7PhO4qh4D8LOIXGTMGgJgB4BvAIwy5o0CMCckEbqLiUPKEhEhxs/lHgEwQ0TiAOwHcD8syf8LERkD4BCAO0ITIqvAiYjc8SuBq+omAOlunhoS1Gg8YBUKEZErc/TEZBmciMiFKRL48bPF4Q6BiCjimCKBf7b2cLhDICKKOKZI4ERE5MoUCXzy9Z3DHQIRUcQxRQJPiI12mOZFTSIikyTw7NPnHabZkYeIyCQJ/MTZ874XIiKqZUyRwKOiHKtMfj5xLkyREBFFDlMk8Gh2xSQicmGKBO5cAiciIrMkcJbAiYhcmCKBM38TEbkyRQJXthokInJhjgTOdt9ERC7MkcCZv4mIXJgigZeXM4MTETkzRwJn/iYicmGKBM46cCIiV+ZI4MzfREQuTJLAXTP44eOFKCgqCUM0RESRwRQJ3F0d+IC/L8Xt76yu/mCIiCKESRK4+zqUXccKqjkSIqLIEePPQiJyEEABgDIApaqaLiJJAGYCSANwEMAdqpofiiBZBU5E5CqQEvggVe2uqunG9DgAS1S1A4AlxnRIuKsDJyKq7apShXIjgOnG4+kAbqpyNB7c2bNVqFZNRGRa/iZwBbBQRNaLyFhjXjNVPWo8PgagmbsXishYEckQkYzc3NxKBdmtZSMsenxApV5LRFRT+VUHDqC/qh4RkaYAFonILvsnVVVFxG09h6pOAzANANLT0ytdF8IhZYmIHPlVAlfVI8b/HABfA+gFIFtEmgOA8T8nVEEa7xHK1RMRmY7PBC4iiSJS3/oYwDAA2wB8A2CUsdgoAHNCFSQAMH0TETnypwqlGYCvjRJwDIBPVXW+iKwD8IWIjAFwCMAdoQuTt1UjInLmM4Gr6n4A3dzMPw5gSCiCcof5m4jIkSl6YhIRkSvTJHD25SEicmSeBO5hfvsJ81DGOz4QUS1kngTuoQheWq6Yu/Wo2+eIiGoy8yRwL8+dLymrtjiIiCKFeRI4K8GJiByYKIF7ea76wiAiihimSeDxsdHhDoGIKKKYJoG3TKob7hCIiCKKaRI4ALRNTnT/BOtQiKgWMlUC//N1nd3OVyOD7zp2GnuzeZ9MIqodTJXAB3VqiuduuMTj88NfX4GrX1tejREREYWPqRI4AIy6Ii3cIRARRQTTJXB32ESciGqjGpHAv9qQhcPHC8MdBhFRtaoRCXzdwXzc8NbKcIdBRFStakQCB4CThSXhDoGIqFqZMoHHRvP2PEREpkzgdeP8uZUnEVHNZsoE/uUf+oY7BCKisDNlAu/YrH64QyAiCjtTJnAiIgoggYtItIhsFJFvjek2IrJGRDJFZKaIxIUuTFfPjLy4Ot+OiCjiBFIC/yOAnXbTLwF4TVXbA8gHMCaYgflyR8+W1fl2REQRx68ELiKpAEYCeM+YFgCDAcwyFpkO4KYQxOdRg/hYjOzavDrfkogoovhbAn8dwFMAyo3pJgBOqmqpMZ0FoIW7F4rIWBHJEJGM3NzcqsTq4tHBHYK6PiIiM/GZwEXkOgA5qrq+Mm+gqtNUNV1V01NSUiqzCo+i2J+HiGoxf3rE9ANwg4iMABAPoAGANwA0EpEYoxSeCuBI6MJ0z1KTQ0RUO/ksgavqeFVNVdU0AHcC+F5V7wGwFMBtxmKjAMwJWZQesARORLVZVdqBPw3gTyKSCUud+PvBCcl/USyBE1EtFtCgIqq6DMAy4/F+AL2CH5L/mL+JqDYzdU9MlsCJqDYzdQJn/iai2szkCZwZnIhqL1Mn8PgYU4dPRFQlps6ASYlx6Ne+icv8n0+4v8HxnuwCrMrMC3VYRETVwtQJXEQw47d98PCg9g7zn5y12e3yw15bjrvfW1MdoRERhZypE7jV8r2OY6xsOHQyPIEQEVWjGpHAne/QU1xW7mFJIqKao0Yk8D5tXevBiYhquhqRwEd2cR0XfMnO7DBEQkRUfWpEAk+Ii3a5U/2f/7stTNEQEVWPGpHAAaBnWhI+HlMxNEuDhNgwRkNEFHo1JoEDwJUdKm4YsetYAbYdORXGaIiIQqtGJXBn1/1zZbhDICIKmRqdwImIarIal8DTmtQNdwhERNWixiXw0nJ1mH5j8d4wRUJEFFo1LoGrY/7Ga4v34HxpGYpL2TuTiGqWGpfA3x+d7jKv86QF6P3C4jBEQ0QUOjUugXe6oIHDdGJcNMrKFfmFJWGKiIgoNGpcAnd2trgsrO+fmXMGJwuLwxoDEdVMNT6Bh9vQV3/AyDfZHp2Igq9GJvCVTw8KdwgOjpw8F+4QiKgG8pnARSReRNaKyGYR2S4izxnz24jIGhHJFJGZIhIX+nD9k9q4LhrEx4Q7DCKikPKnBH4ewGBV7QagO4DhItIHwEsAXlPV9gDyAYwJWZSVkBAXHe4QKIyOnDyHrHz390almu1A3tlaMw6SzwSuFmeMyVjjTwEMBjDLmD8dwE2hCLCynrvh0nCHQGHUb8r36P/S0nCHQWEw6JVltWYcJL/qwEUkWkQ2AcgBsAjAPgAnVbXUWCQLQAsPrx0rIhkikpGbm+tukZAYfukF1fZeRETh4FcCV9UyVe0OIBVALwCd/H0DVZ2mqumqmp6SkuL7BUE0/BL/kviuY6dRVBLe5oZERIEKqBWKqp4EsBRAXwCNRMR6pTAVwJHghlZ1T1zT0e38W6b+iJ9PWOpH888WY/jrK/D0V1uqM7Raq6ikDB+vPgh1HvOAiALmTyuUFBFpZDxOAHA1gJ2wJPLbjMVGAZgTohgrrX3T+m7nbzh8Ele+bKkfPVtsqQXKOJhfbXHVZi/P340/z9mOBduPhTsUItPzpwTeHMBSEdkCYB2ARar6LYCnAfxJRDIBNAHwfujCDD2WCKuHtVfqmfOssqKaT1WRfbooZOv32VhaVbcAuMzN/P2w1IfXOKVl5SgtV8THBq8pYlZ+IVIbm3Os8jPnS5EQG43oKKn6yoxV8IBJtcG/V+zHC/N2Ycn/XYV2KfWCvv4a2RPT3vpnhnp87sz5UrfzR3+4Dp3+PD+ocdz29uqgrq+6lJcrLp28ABNmbw3K+sTI4EzfVBUlZeX4Yt3PKC+P7G/Sir15AICs/ND0xq7xCbxJvTr445AObp97atZmiFgSSkFRRTJfmZkX9DhyCkJ3GhVKZUZJ+asNWUFZn1gL8ZH9u6MI996KA3jqqy2YtT4438tQsZ5oBuHc1a0an8AB4PGr3bdGWbwjx/a44HwpDuSddXh+yc7sSr3fD3tyUVLmeAMJs+arMqOEEyXB+QqG6otcnUrLymt9FVBBUQlyC86H7f2Pn7G896lzkT1MtBq//CD9fFzUigQOAEmJrkO1FJeVo9Qu0e7PPePw/HfbAm8psXrfcYz6YK3LrdzM+nsv19B8AdWkh7TyckX7id/hL9/uCHcoYTXw78vQ83neJMWXihJ4aDJ4rUngni7AXfX3ZbbHwahOyzVKBgeOn/WxpDkEvQRuu4gZlNVVO2uV0serD4U5kvA6fpZj3PvD+j0PxvV/d2pNAr/5Mrc9/R38sCfHYdo+yby3Yj8yDp4IdlgRr9w4QQnWF9DsFzEDPfCUlyvu/3AtfgzBdRWKfLYzTSbwqhk3vBM6N2/gdZmDeYW2HprO/jZ3J257x3dLEmvdaE2o6wWAUiODswRuEWidZkFRKZbuzsUDn6wPYVS1V6RXxYX6e15rEnhUlODjMb3w5l2X4cCLI9wuszIzz9ZDs6okwISnqg718ZHCWmUQFaQiuC2BR/gPzxPrD9KsB6CaIlQXBYPN+jVhHXgQNKlXBzd0uzDg5FodXl6wG+0nfofi0shK4sGuQrGem9SWBGjWAxUFibUGhVUo1e+HPTm4+98/4af9x12eO3G2GDt+OR209/rEuChWVBpZXcxtJfAgfQPXH7JcRzBrWqtsq5xILDRQ6Nmq3EK0/lp737G7erXCZ2sPe10m70wx8s4cx6HjrvXi1/9zJY6cPIdJ13VGSVk5fn9VuyrFE46EVlpWDhHx2kXe2tMtGFUoRSVl2JNtNNU0aRHcpGHXWJG+P2zNCEN0AK+1JfAXb+mC7i0b+bWsu5sSW+f95dsdePG7Xbb5Ve155et1qoqf9h8PSkeS9hO/wy1Tf/S6TEUzwiq/nW1dQA0ogUfQZeojJ88hbdxcLNud43W5T9ccxsC/R8ZdijYczsee7IJwh+FTSVk55mw6Uunfm60OnFUowfffh/phRJfA7tyz/lA+znoYQyX7dBEem7kJgGWHOTc7nLPpiG00vspasD0bd077CZ/8FFg75HYT5uHZb7a7zN+c5f3egcGuQjG7SDzwbDp8EgDwRcbPXpeb8PVWHHRzNhkOt0xdhWGvLa/066urSurtZfvwx883Ye7Wo1VaD7vSh8g1ft61x+qrDVm4ZPICt8/Zl4DyC0vw4Y8HHZ7/4+eb0P0vi7yu31eCsDZzDPSHWFau+M+qgz6Xc/c6wHsCP3O+FF9v9D0mhf22RfqpryeBxh3M7Xxh3k68NH+X7wV9sC9NZuYU4I53V3sslNR21qFg8yvZcSnUQy7U+gSeXK9OQMt/usZzvXlJWcXOWr4n1+dR+6PVBzF3i2UZ645WPxuheBsDYtex01X64uQWnEfauLlYuTevIoG7+aacLipBYXEpJszeisdnbsaWrJNe11tuF1O5m/iy8gvxXRVLOqEW6OcazJ/vtOX78fayfVVej32P4xfn7cLaAyewel/FhfrFO7Jx89QfI36kPzNgFUqIXdGuCabe0wNjB7St0noKikoCasf9py82YdKc7Xjo0w0O8/1tduZpFLYfM/Mw/PUVmOHlQOPO2fOltrvkbDxsuTvRf1Yd8FoC7/rsQvR98XscO2UppRQWe29BY39wcpcHb566Cg/M2OD6RATxJ39n5RfiVGGJsXzlkuDFf56Pl/0sbQfaVLHMR2J+5LON2Hj4JM65uU/s+NlbkDZubkDvV1XHz5z3GXOoVDbxni8tw7qDJ3gRM9REBCO6NMeEERdXaT09n1+MOZt/8Xv52RscbyFq/XrO33YMG4wEqqoupSD7H6u1tHrsVJHtzOB3H2UAsJTCAaDLswsw+B/LfMbzxJeb8fuP12N/7hm7dxBbSdlTFcqpcyVY6+cQA/albuuj/LPFtrbv1tHtIrnk509k/V9aimGv/wCgorQb6O/3XEkZpgahtO2Or2RY0dnK1Wdrvdez28s5XYRpy/dhn9MgcYE4XVSCy/+2GM/P3VnpdQSDt08s/2yxy7Wt5/63A7e/sxqbfj4JgHXgEa+opBwbjYtJgSovV1vpddzsrbhl6iocPXUOz8/dibYT5jmU4uwLdA/M2ABVxegP12LC11uRd+a8bT0xRp1HQVEp9uf6HljL+iMrKVOHAXisP/acINwWqswu+NyC87hk0nxc9tdFeHCGYzfzkvLQdmYqL1f87qMMh2oDv1/rZzOj7NOWg1EkduQp83FW4G7TikrKMHnONr/fo7i0HL1eWIIX5u3CrW+vCjDCCtYzmareQ7WgqMQlyX6x7mes2ud9jBp/Whtd9tdFLte2dh517CPCEngN8s4PjiWrfi9977JM3xe/x3srDwAAfjs9A6eLSlBSVo5DTmO1vL54L3YdszTHsv9deiox935hse1HYc9afx8bLRXjuUhFwjrro3rEH/Yl8GW7c2zrXLzTsflbaZn3BLN0V47tDKMyCopKsWhHNsZ+nOEwf+XePMxc57nqaV/uGaT/LcAhVIOUv+3Hl//FrlnrkZPnXIYsVVW8OG+nx2sSZR4+38LiUvR+YbFtv9gXHGZvOILpAYzAeN6uQ5q3C6RvLc2sliEkehhJNrfgvO1zeeqrLXiomqrsWAKvRp+P7YOOzYJ//zqrKd851m0ePeW9dLtkVw66PrsQI99c4XIR9Y0lFeOO258aH8g74zImOWApGXb7y0KX+dZqjCgRW85ZsD0bp4scf3xnzpdi4tdbPd6Ozt6+3DPYdqSimaL9AcZ60LFnbWteWq44c77Udvo5a30W0sbNtSWC+/+zDsNfX+Hw2n8v349Vbkb8Ky9XfLz6IP7yvx341/eWz8N6ILHvwPTMf7fi3vfX4OmvPN86zv4GHyVl5fj4p0NoO76iPnjl3jyH+mFVtVWhnCwssSXEbUdO4ZQx/cOeXFuVUUlZucfqo+GvL3d5vP7QCfSb8j1mG3dLspb2S8sV7y7fjxvfcmzjbz2me+rtm5lzxnbmAFQMowA4JmRnpwpL8KVTE0b713qrsvn7gt34euMRl/nrD+U7HEDsyyPHThVh2vL9HtfpjrWAcu0by3HDvyo+l3w3hRl71usAZeWKzJzKt1sP1XlYre2J6c4rt3fDmv3H0adtE7x7XzoGvbIs3CE5sPVi9OAfC3fbHi/dnYulu3M9LvvrD9baHr++eI+tY9IDMzbguq7Nbc+N+2qLw+v+8+MBzFhzGM0axLtdr6pi6e4cNGsQj5FvrgQAzH7wCrROquu25YnVj5l5iBJLnXtRSRl6v7AEAPD7q9pi4XZL4jxy8hw6Nqtve82Kvbm4skMKDh8vxPPzLHWkB6eMdFhv2wnzHKZbN0lEn7ZNAFiSamFxKerGxeCTnyoOjDPXHUa/9skON6HOzCnA2gMVdf2qwJ//a6lS2HA4Hz1aNbYlUqs24+fhhycH2qZPnytFg4QYXPfPlWibnIjHr+6IRz7biFsua4HZRhK7q1crvHDzpS6fzz67arDTRaVQVdxq3Gd1g1PVnTVhqlbEBlgOzmWq6P3CEvzn/p4Y/eE6XN66se11zneRKlfFycJi/LT/hMckrKp4/ItN+H5XDrq3bIQOxv6xrwbzdUnjyVlbMPCipkipb2kRtmx3DkZ/uA6Tr++MIZ2auSz/6Ocb7T6XMzh0/CxaN0lEUUmZ274O9vLOWKpRJnzt3z1erY0Fnvuf5QYeCx8f4PAd9MS5xL3r6Gm/Ow4Gggnczm2Xp+K2y1MBADGhGoE9hL4M4P6Ay/dUJPfX7UrqO4+edqi/sy+R/fXbHXjfqNZ5ddEel3XO3pCFO6f95DL/lqmr0CY50esX+J731tgev2a37nd/qChp/WPhbrx7X7pt+r731+KTMb1x7/sVr738r4uQ2jjB4/s88tlG/Lpva9t050kLMO/RKx2WsZbC9/ztWuw4ehotGydg6KueO53M3pCFW6a6r+e1v2FIYUkpNhmn7/vzziLHuGg7264E+tnaw7i3Tyvb9MLtx7DFTWcr+8/Z2qRUIMjMKXA407ll6ir84/ZuuPXyVMs1DWP+6A/XAQC2GmdIP+7Lc7kmcPxsMYa+arkYO8ruM7OnWlGlU2wcANYfyndbYi8uLUdOQZHDgdFqb04BUurXwcnC4orYsk6hdxvLwTYr/xwO5p1FWnIiztlV532RkYUvMrLwzr2XI7+wGJ+v8+8iq/2Z7NiPMrBwRzY2TxqGhnVjvb7OvhDxxuK9OGZ3bWjbkVO4tEVDt6/7x6I9uLNXK7fPVYXPBC4iLQF8BKAZLGcC01T1DRFJAjATQBqAgwDuUNX8oEcYJi2TKr5kN1/Wwu1pXm1jTd6efJHh+QByIO+syz1HPfH0I1ywPRt9X1ziMM8+eQOWpOPrbjEfOdXlvrfS/el4x2e+8xUqADiU3r1ZfyjfoSQbF+O+BtN65gIAYz92P474mgOuLX/mbj3qtu/BD3tycevlqQ79FKysVWfOnc4A2JI3AI/13+WqtjOr/248gk4XNPB40XLC11sxa30W3r3vcpfn/vV9Jk6cLcYHdt+x2RuPOBzcBr6yDG/c2d120LG3al8eLnYa7z8rvxAfrDyI1k1cDxj2Fu6wnOF9tSEL/Tsk2xK0u+osS4ODUkyes92lwHTdP1fi4JSReHXhbpezotyC88gpKELT+u7PXCtLfLVTFZHmAJqr6gYRqQ9gPYCbAIwGcEJVp4jIOACNVfVpb+tKT0/XjIwMb4tElFOFJZAoIC46Cvtyz+BgXqFLu22iQLz2q254fOZmAEDblES/WggFw8u3dsVTTtVhwdC9ZSPbtQpvEuOig3Ih3Bt/Bqjzx4qnBmHVvjx0bFYfN3s4s/KkRaMEt2MnAcDSJwaiTXJipWISkfWqmu4yP9COBiIyB8C/jL+BqnrUSPLLVPUib681WwJ352RhMRrVjcPfF+zCW0tD006Xaq6HBrXj96aWWj1+MJo39Fy9542nBB5QKxQRSQNwGYA1AJqpqvV87RgsVSzuXjNWRDJEJCM31/NFNbNoVNf17vb2Jl/f2evzY/q3CWY4ZDJM3rVXfEx00NfpdwIXkXoAvgLwmKo6NMJVSzHebVFeVaeparqqpqekpFQp2EgydoD78b+jRPDEsI4eX2e9SOqPd+7t4TLvfw/39/v1RBQ5GiR4v0BaGX4lcBGJhSV5z1DV2cbsbKPqxFpP7n0w4hqmoYedESVA+6aWNuQX2TU3srY5bpdSD5snDcO6iUMx47e9cU9v91em7+vTGsMvbY6Jdl38r+7cDF1SK65y/zR+SJW3w52eaY3dzp//2JWY9Ye+Xm8A4e3gRVSbefvdVJbPBC6WPqDvA9ipqq/aPfUNgFHG41EA5gQ9ugi3buJQrJs4FKvHD7aVrO27zLZuUhcHp4zEwSkj8eHonhh6cVPERgsa1o1FSv066Nc+Gc/f3MW2fKcLKhL+X2+ytAX+3YC2ODhlJDZPHoap9ziWyC9o6P8V7Zdu7YJBF/l3BvTW3Y7v07xhPBY+PgCdLmiA9LQkXHOJY23ZR7/phW8f6Y95j16JKztUvEd6a9cDgacD303dL/Qa079/7VL959XHY3ph4eMDAnpNbbRu4lCPrWHIVVKi9yrU6ubPnusH4D4Ag0Vkk/E3AsAUAFeLyF4AQ43pWiWlfh2k1K+D5g0TcMmFliZMliZLrkfaAR1T8N6onm7HRLi1hyX5e0tSDRNiERvte3c9eY3jdeROF9THuolD8auerTDt1+l4ZHB7vHRrFw+vtmiQEIvebZIw5ZYu2PfCCKweP8Sh84L9de/f9GuDKzsk49IWDdH5wgYotWt69f7onrbHK54ahA/v74nNk4fhm4f74anhjnHe0bOl15iuaNfE6/MA0NmuGdmVHVLQLsW1N+3aiUPwzcP9bNMjuzZ36GzjzYeje+JZH9c41k4YghVPDXL7XNdU922EAcsB9ss/9PW6but3zJMZv+3tMP3W3T1wcfMG2P7cNTjw4gi3r0mpXwdXdXR/YPc01PLaCY5nfvf3S/O4zcHw+dg+ACytwUJh86RhLvPu7dMKv7/KcYTSLi0aYsOfr/a5vktbuO6nOiE6SPpcq6quVFVR1a6q2t34m6eqx1V1iKp2UNWhqurfkHQ11Ogr0vDfh/o5lED9bd8z5dYuWP/MULRMqouWSQkYf22nSsWQXC8ODw1qb5vumdYY8x8bYOvhFhsdhf8bdhF+1dN7h4IoEcz8fV/c2auV29M+awKfek8PTLq+s8NBydrOOb11Y4fSdsukuhh0UVMAQNfURhjWueJGGq2S6uKKdsn48P6KhL/12WG4ol0TLHtiIA5OGYnEOp67LCTEWi4OzX20P1aPH4zFf7KUvKOjBPf1qeiA8szIi9G0fjy6pjayve6tu3ugdZNEW8etVeMG45pLmuHbRyquNXz7SH/c26cVruqYgtH9Ki5Ct0qqi11/HY5/3X2ZbV7TBvEOfQjsffq7PrbH13e7EB2a1sPEERfjfw/3x696tkLPtCSXA1u9OjH44UnLZzDXrsORfUJeM2EItj13Dfq1T3bocj6ya3N898crkVgnBiKCF+zO9n6V3hILHrN8TvZ7uGn9iqQdF215Ji4mCrfbXbtp6tQLd/L1lzhs85d/6OvQaWvSdZ2x74UROPDiCIeDrNVFzeo7vC9gOTOwSm/dGG2TE/HmXd1dzg6dzwatXr6tK964s7vDvLYpiVg3cSjuSHe8DtWwbqzts7Dq3z4Z4691HKG0ZZKlBcnSJwa6fU+rbx+5EgenjMQ3D/dD47qxuLVHKmY/eIXX11QWe2IGiYjYvrSBDjwWGx2FJkZpZ8VTg30u/9P4IX6d9v7n/l4BxTGqb2s0SIj1ue6JIy9GaXm5LSHbKzW6UMdE+/chtE1OxPfGD8J+ffXjYx0SnlW31IZ4ZHAHS2m/TFG3TjROnSvB6n3HISIuzbQmXd8Zd/VqhdSkBDSIrzigfPmHvg49Ntc/czW2/XIKFzZKcOjtCQCXtmiIv7WoSH7P3XAJJn+zHfXjYxAfG43rul6Ihz/dCF/q2R2E/nnXZW6XeXBge7w8f7fDvNZNKtoOrzFKvyKC2GhBSZmiXp0Y2wHuwIsjPY7XfXfvVrYu5C/d1tU23zrw2dR7emBEl+bILTiP7NNFtqGJf3hyIJo3TMD4ERfj+BlL71F3zSF/HDcYMVGCZg3i8fGYXsg+fd52PchqzsP9UFRShp1HC7D+UD5emr8Lv+rZEtkFRQ69buvHV3xWMdFRtu8IADz0acX63r0vHYXFpfjl5DmH3rL92iejRaMEPD93p63H6yu3d0NK/Tr409UXuXQ669C0HpIS43DC6AQ20Pgu1o2Lto3wae0V2iY5EVueHYZDeYW4/l+WTlebJw1zGWOoa2ojbHRTug8mJvAQsJ56tk2pXKN9XzzVffdrn+ww7a3Ueu2lFyA6SvDsDZdgyc5sPP3VVtzcI9Wv8RpaJtXFe6N6un2uZ1oS7khPxSODOwCwlFYO5LkbwyXwuz9vmnQ14mOjER/r2BwruV4dt9UlgOXg2NlN1UPPtCSH6YZ1Y10+v0/G9MbpItfBjqzjh3jrQvG/h/sjOkow4k3LoFvW5N2nbZLPMW28sR+Dxnq241y1Num6zmhSz/+62i6pDTF/+zE0N75X1qrBimGFLTspKTHOVgdsbRL30KCK1lgtGlUcEOvHx6J+vOv1jtjoKMRGR6FXmyT0apOE3w9oCxHLZ/nAVe3Q/S+L8Ojg9n5VF1rVjYtx6WUaa5xRNUyIRU7BeXw8ppdtTBirxLhorDYOiFHGb+HRzzZiZNfmtu+Y9TP++sErHH4bDeJjkRBXEaO1C35115EzgYfA5a0bY8Zve6NXmyTfCwfJ0icG4sJGlh/g4E5NkezjB/z2vRXdme9Ib4mrOjYN6KKoJ7HRUXj5tm626TbJiW57n/k5rLYDX23wg61/h2S389s3rYeOzephkl19eItGCQ511F2c6rs3T7aUxD4f672e25m3jnadLmiAHUdPu4zb85sA+xo8cFU7DLwoBZdc6BjzK7d3w2uL96CJm6TUzihZ+zOwkzdRRuwilv3rXFfv6aI3ACx/sqLe3XkI4hjjAPDufZfj83U/o397131ZLz7G4azMWuq3317rx9+uaT2X61fOY7qsf6b6LwgzgYeIc2kuVGaO7YO8M8UOSfKD0e5Lx56ISFCSd20RHxuNhY9f5TDvx3Geq766pTYMqAnZrD/0hcJyE+OHBrb3uNwnv+2NPdkFtiToj6eGX4QUp4uTUVHikrwBywHM00FsRJfm+PaR/j4vrAbKPkm+ekc3h9ESnbWyG+PkkgsbOFTrxBpVeG1T6rncbct6QbHTBY6xD+yYgim3dMGN3VvY5lnHeYl1c1PY+NhorJkwBEXGkLNNAry/bjAwgZtc77a+W2dQ+GQ+f23Ad2NJN6p3vn6wn9flkhLjbEPj+utBLweEQHkaeS9Ybunhf6e3qCjBk9d0wjs/7EdZuXqtgmmcGIfPx/ZxOfiIiMuIgda7F3m6puNpWOXqwgagFBYVd+s237C9gYiJjgpJB47abNW4wVjmoSWINSn7Gg66T9smbuvonf3aaMUUqcNLswROYWH9PSQ4XZBsm5yI/X4OO0u104WNPA8INf3+XtidXWCrA6+qyddfggkjL47YggYTOIVFu5R6eGxoB5exYb55pD/OFPm+XRuRO40rUa3kTVSUoE5U8AehChYmcAoLEcFjQ13HTalXJ8ahvTQRecY6cCIik2ICJyIyKSZwIiKTYgInIjIpJnAiIpNiAiciMikmcCIik2ICJyIyKfE2XGXQ30wkF8ChSr48GUBeEMMJJ25L5Kkp2wFwWyJVVbaltaq63PuuWhN4VYhIhqoGdmfbCMVtiTw1ZTsAbkukCsW2sAqFiMikmMCJiEzKTAl8WrgDCCJuS+SpKdsBcFsiVdC3xTR14ERE5MhMJXAiIrLDBE5EZFKmSOAiMlxEdotIpoiMC3c8vojIQRHZKiKbRCTDmJckIotEZK/xv7ExX0TkTWPbtohIjzDH/oGI5IjINrt5AccuIqOM5feKyKgI2pZnReSIsW82icgIu+fGG9uyW0SusZsf1u+fiLQUkaUiskNEtovIH435ptsvXrbFjPslXkTWishmY1ueM+a3EZE1RlwzRSTOmF/HmM40nk/ztY0+qWpE/wGIBrAPQFsAcQA2A+gc7rh8xHwQQLLTvJcBjDMejwPwkvF4BIDvAAiAPgDWhDn2AQB6ANhW2dgBJAHYb/xvbDxuHCHb8iyAJ9ws29n4btUB0Mb4zkVHwvcPQHMAPYzH9QHsMeI13X7xsi1m3C8CoJ7xOBbAGuPz/gLAncb8dwA8YDx+EMA7xuM7Acz0to3+xGCGEngvAJmqul9ViwF8DuDGMMdUGTcCmG48ng7gJrv5H6nFTwAaiUjzMMQHAFDV5QBOOM0ONPZrACxS1ROqmg9gEYDhIQ/eiYdt8eRGAJ+r6nlVPQAgE5bvXti/f6p6VFU3GI8LAOwE0AIm3C9etsWTSN4vqqpnjMlY408BDAYwy5jvvF+s+2sWgCEiIvC8jT6ZIYG3APCz3XQWvO/wSKAAForIehEZa8xrpqpHjcfHADQzHpth+wKNPdK36WGjauEDa7UDTLItxmn3ZbCU9ky9X5y2BTDhfhGRaBHZBCAHlgPiPgAnVdV6Z277uGwxG8+fAtAEVdgWMyRwM+qvqj0AXAvgIREZYP+kWs6bTNl+08yxG94G0A5AdwBHAfwjrNEEQETqAfgKwGOqetr+ObPtFzfbYsr9oqplqtodQCospeZO1fn+ZkjgRwC0tJtONeZFLFU9YvzPAfA1LDs221o1YvzPMRY3w/YFGnvEbpOqZhs/unIA/0bFqWpEb4uIxMKS8Gao6mxjtin3i7ttMet+sVLVkwCWAugLS5VVjJu4bDEbzzcEcBxV2BYzJPB1ADoYV3bjYKn8/ybMMXkkIokiUt/6GMAwANtgidl61X8UgDnG428A/NpoOdAHwCm70+JIEWjsCwAME5HGxqnwMGNe2DldX7gZln0DWLblTqOlQBsAHQCsRQR8/4x60vcB7FTVV+2eMt1+8bQtJt0vKSLSyHicAOBqWOr0lwK4zVjMeb9Y99dtAL43zpw8baNv1XnVtrJ/sFxV3wNL/dLEcMfjI9a2sFxR3gxguzVeWOq6lgDYC2AxgCStuJL9lrFtWwGkhzn+z2A5hS2BpS5uTGViB/AbWC7GZAK4P4K25WMj1i3GD6e53fITjW3ZDeDaSPn+AegPS/XIFgCbjL8RZtwvXrbFjPulK4CNRszbAEwy5reFJQFnAvgSQB1jfrwxnWk839bXNvr6Y1d6IiKTMkMVChERucEETkRkUkzgREQmxQRORGRSTOBERCbFBE5EZFJM4EREJvX/HMn9p4Hc4wQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.plot(svi_result.losses)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlMAAAEvCAYAAABhSUTPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaRklEQVR4nO3df4xd9Znf8fcTA+s6JYnXsKJiTGcsYynxujulNslqtQppjJdg2USpd8HVSqyKoGxicLPpNlAqlLqRvEksW6sZJhQ3SZUVLYEW05FsiuMttNtoja5t7ro1lNQ7yeIhGWXWNlR1ahI73/4xY3MZz4/jOefec++575eENPfe4zmPco3y4fk+5/uNlBKSJEman/eVXYAkSVInM0xJkiTlYJiSJEnKwTAlSZKUg2FKkiQpB8OUJElSDleUdeNrrrkm9fb2lnV7SZKkzA4fPvzXKaVrp/ustDDV29vLoUOHyrq9JElSZhHxVzN95jKfJElSDoYpSZKkHAxTkiRJOZQ2MyVJkqrp5z//OaOjo5w9e7bsUi7bwoUL6enp4corr8z8ZwxTkiSpUKOjo1x99dX09vYSEWWXk1lKiZMnTzI6OkpfX1/mP+cynyRJKtTZs2dZsmRJRwUpgIhgyZIll91RM0xJkqTCdVqQumA+dRumJEmScjBMSZIk5WCYkiRJlXT+/Hm2bt3KypUrWbVqFSMjI025j0/zSZKkptr13e8X+vs+f+uKTNdt376dZcuWcezYMXbv3s3Q0BA7duwotBawMyVJUscZHxgsu4S2d+bMGfbs2cPWrVsB6Ovr4/jx4025l50pSZJUOQcOHODEiRP09/cDcOrUKdauXduUe9mZkiRJlVOv19m2bRv1ep16vc66devo7+/nzJkz3H333dx77708+eSThdzLMCVJUgdwae/ynD59mkWLFgFw7tw59u/fz4YNG3j22WfZtGkTu3fvZnh4uJB7GaYkSepQ4wODhqwZrFixgoMHDwKwa9cu1q9fT19fH6OjoyxduhSABQsWFHIvw5QkSW1mqD50yXu1sRr7Hrnb8JTR5s2bOXLkCMuXL+fo0aPs3LkTgJ6eHkZHRwH4xS9+Uci9HECXJKkNDdWH+Gz/Z2f8/HJC1YVrr31gS+665iPrVgZFWrx48cXOVKPPfOYzbNmyhb1797Jhw4ZC7mWYkiRJXeP9738/3/rWtwr9nS7zSZIk5WCYkiSpAhxGL49hSpIkKQfDlCRJFTK1O2W3qvkMU5IklWS6LRCK4rJf6ximJEkq0VB9aMZQNdtnah+GKUmS2lTvMy/P68/ZkWot95mSJKlN7Hvkbn742x+95P2h+hC9rS9HGRmmJElqM1k7UrWxGmuuW2MnqmSZlvki4raIeD0ijkfEQ9N8fkNEvBgRr0TE0Yi4vfhSJUlSbax28R/N7vz582zdupWVK1eyatUqRkZGmnKfOTtTEbEAeAy4FRgFahExnFJ6teGyfwE8nVL6ekR8BNgHdiQlSRLw4vZif98nHs502fbt21m2bBnHjh1j9+7dDA0NsWPHjmJrIdsy383A8ZTSCEBEPAXcATSGqQR8YPLnDwI/KrJISZK6xXyHzvVeZ86cYc+ePRw+fBiAvr4+9u7d25R7ZQlT1wMnGl6PAlOn474E7I+IB4D3A2sLqU6SJGkeDhw4wIkTJ+jv7wfg1KlTrF3bnHhS1NYIm4F/m1LqAW4H/iQiLvndEXFfRByKiEPj4+MF3VqSpM6XZz8pZ6guVa/X2bZtG/V6nXq9zrp16+jv72dkZIR77rmHTZs2FXavLGHqTWBpw+ueyfca3QM8DZBS+nNgIXDN1F+UUnoipbQ6pbT62muvnV/FkiRJczh9+jSLFi0C4Ny5c+zfv58NGzawbNkyvvGNbxR6ryxhqgbcGBF9EXEVcBcwPOWaN4BPAkTEh5kIU7aeJEnKqfeZl52jmocVK1Zw8OBBAHbt2sX69evp6+tryr3mDFMppXPAFuAF4DUmnto7FhHbImLj5GVfAO6NiL8A/j3weyml1JSKJUnqQB4N01qbN2/myJEjLF++nKNHj7Jz586m3SvTpp0ppX1MbHfQ+N6jDT+/CvxGsaVJklRNZYWq8YFBrn1gS+tvnHErgyItXrz4Ymeq0cmTJ3nkkUd45ZVX2L59Ow8/nL82d0CXJEldY8mSJTz++OOF/k4POpYkScrBMCVJUgdr3BLhcrZH8Dy/4himJElqIYfQq8cwJUmSlINhSpKkJrITVX2GKUmSpBwMU5IkSTkYpiRJKlHRR8V46HHrGaYkSZJyMExJklRBdqfg/PnzbN26lZUrV7Jq1SpGRkaach+Pk5EkqQna9Sm+MjbrLPp/i8/2fzbTddu3b2fZsmUcO3aM3bt3MzQ0xI4dOwqtBQxTkiSVrui5KcGZM2fYs2cPhw8fBqCvr4+9e/c25V6GKUmSVDkHDhzgxIkT9Pf3A3Dq1CnWrl3blHs5MyVJkiqnXq+zbds26vU69XqddevW0d/fz3PPPce9997LnXfeyf79+wu5l2FKkiRVzunTp1m0aBEA586dY//+/WzYsIFPf/rT7N69m8cff5zvfOc7hdzLMCVJkipnxYoVHDx4EIBdu3axfv16+vr6Ln7+5S9/mc997nOF3MswJUlSlyrjyb5W2bx5M0eOHGH58uUcPXqUnTt3ApBS4otf/CKf+tSnuOmmmwq5lwPokiSVoJue4Mu6lUGRFi9efLEz1WhgYIADBw7w9ttvc/z4ce6///7c9zJMSZLUZO2651Q3evDBB3nwwQcL/Z0u80mSJOVgZ0qSpC7WODd17QNbSqykc9mZkiSpompjNc/oawHDlCRJLdL7zMtdNXjeLQxTkiS1mIGqWgxTkiQVzKf3uothSpKkinNuqrkMU5IkSTkYpiRJEjCxTUKVjpg5f/48W7duZeXKlaxatYqRkZGm3Md9piRJUlMVHdCy7oe1fft2li1bxrFjx9i9ezdDQ0Ps2LGj0FrAMCVJkirozJkz7Nmzh8OHDwPQ19fH3r17m3Ivw5QkSQWZ7Sk+t0NorQMHDnDixAn6+/sBOHXqFGvXrm3KvZyZkiRJlVOv19m2bRv1ep16vc66devo7+/ntdde4/7772fTpk18/etfL+RehilJklQ5p0+fZtGiRQCcO3eO/fv3s2HDBj784Q/z+OOP8/TTT/O9732vkHsZpiRJUuWsWLGCgwcPArBr1y7Wr19PX18fAMPDw6xfv57bb7+9kHsZpiRJKoC7nreXzZs3c+TIEZYvX87Ro0fZuXPnxc82btzI888/z5NPPlnIvRxAlyRJTZV1K4MiLV68+GJnqtFLL73Es88+yzvvvFNYZ8owJUmSusYtt9zCLbfcUujvdJlPkqQuUBureUZfk9iZkiQpB2elZGdKkiQpB8OUJElN0vvMy+583gUMU5IkqXAppbJLmJf51G2YkiRJhVq4cCEnT57suECVUuLkyZMsXLjwsv6cA+iSJM1TlYfPxwcGgfntEdXT08Po6Cjj4+NFl9V0CxcupKen57L+jGFKkqQm67a5qSuvvPLi0S3dwGU+SZL0Hhe6UsrGMCVJUpdx885iGaYkSZJyMExJktRF7EoVzzAlSZKUQ6YwFRG3RcTrEXE8Ih6a4ZrfiYhXI+JYRPy7YsuUJElqT3NujRARC4DHgFuBUaAWEcMppVcbrrkReBj4jZTS6Yj4lWYVLElSJ+i27RC6WZbO1M3A8ZTSSErpZ8BTwB1TrrkXeCyldBogpfSTYsuUJEllcJuEuWUJU9cDJxpej06+12gFsCIivhcRByPitqIKlCRJamdF7YB+BXAjcAvQA/y3iFiVUnqr8aKIuA+4D+CGG24o6NaSJEnlyRKm3gSWNrzumXyv0Sjwckrp58APIuL7TISr9zx/mVJ6AngCYPXq1Z11+qEkSZOqfCafLl+WZb4acGNE9EXEVcBdwPCUa55joitFRFzDxLLfSHFlSpIktac5w1RK6RywBXgBeA14OqV0LCK2RcTGycteAE5GxKvAi8AfppRONqtoSZKkdpFpZiqltA/YN+W9Rxt+TsAfTP4jSZLUNdwBXZIkKQfDlCRJGVVp8Lw2VvOcvoIYpiRJknIwTEmSJOVgmJIk6TJUaakPcKmvAIYpSZKkHAxTkiQVpPeZl8suQSUo6mw+SZKEgaob2ZmSJEnKwTAlSZJmNT4wWHYJbc1lPkmS5lC1J/hULDtTkiRJORimJEkqgIPn3cswJUmSlINhSpIkzWl8YNBB9Bk4gC5J0izmGj6vwvLehSNl1ly3puRKOpOdKUmSpBwMU5IkSTkYpiRJUmbOTV3KMCVJkpSDYUqSJCkHn+aTJGka3XiETG2s5hN982BnSpIkKQfDlCRJUg6GKUmSpBwMU5IkSTkYpiRJknIwTEmSJOVgmJIkaZ6qcMix8jNMSZIk5WCYkiRJysEwJUmSLsv4wKAHHjcwTEmSJOVgmJIkScrBMCVJki6qjdWojdXKLqOjGKYkSZpiqD5UdgnqIIYpSZKkHK4ouwBJkjqJG3VqKsOUJEmTXN7TfLjMJ0ma2Yvb3/1HmsK9piYYpiRJknIwTEmSJOXgzJQkdaPGZbtPPFxeHVIFGKYkqdvNJ1hNnaEykFVObazGmuvWlF1GR3CZT5IkKQc7U5LUDZr9NJ7LhupihilJ0rvcAkG6bC7zSZIk5WBnSpKUzXy6Vg6qqwsYpiSpSlymk1ou0zJfRNwWEa9HxPGIeGiW6/5BRKSIWF1ciZIkSe1rzs5URCwAHgNuBUaBWkQMp5RenXLd1cBWwOO0JambzdYd86m/jlIbqwG439QcsnSmbgaOp5RGUko/A54C7pjmun8FfAU4W2B9kiS1xFB9qOwS1KGyzExdD5xoeD0KfLTxgoi4CViaUtobEX9YYH2SJLWF3mdceNH0cm+NEBHvA3YCX8hw7X0RcSgiDo2Pj+e9tSRJKtn4wGDZJZQuS2fqTWBpw+ueyfcuuBr4VeCliAC4DhiOiI0ppUONvyil9ATwBMDq1atTjrolSZ3O+SlVRJYwVQNujIg+JkLUXcA/vPBhSult4JoLryPiJeCfTg1SkqSCuP2B1FbmXOZLKZ0DtgAvAK8BT6eUjkXEtojY2OwCJUlSexsfGOzq5b5Mm3amlPYB+6a89+gM196SvyxJkqTO4Nl8kiTNwSf5NBvDlCRJUg6ezSdJGez67vcvee/zt64ooRIVzc06lZdhSpKmmC44lc4n+KS2ZZiS1DWK7i7ZrSrQbGHRPajU5gxTkiqpLbtLkirJAXRJkqQc7ExJ6mqt6GDNdI9ZlwSdkVIbqY3VWHPdmrLLaFuGKUkqUK5wZoCSOpLLfJKk9vbi9nf/KZBbIqgohilJkqQcXOaTpJJMXRL82Bsn+fVlS0qqpjvZncrOuamZ2ZmSJGkWnsunudiZkqQW+tgbT7zn9cEb7iupEklFMUxJkjrH1CF0d0dXGzBMSVKJpnaqdJkaw1XGYOWclIpmmJLU8ap0dMyfj5y85D2H0qX2ZpiS1FGqFJykqhkfGOTaB7aUXUbL+TSfJElSDnamJEmahlsiKCvDlCQ1mUPmUrW5zCdJkjKpjdWojdXKLqPt2JmS1LYcNp/gE35Se7MzJUmSlIOdKUltwS6UWsENO9UMdqYkSZJysDMlSU3gE3wlmMfRMlIRDFOSWs4lvfwcSm8u95jS5XCZT5IkFWZ8YJDxgcGyy2gpO1OSJE2yI5VNbazGmuvWlF1G2zBMSVIBnJFqM43zU8DQ4g+WVIi6gct8kiRJORimJEmScnCZT1JT+eRe6/iEn1QOw5QkzZNzUpLAZT5JkqRcDFOSJEk5uMwnSZfBpT1pQm2sBjDjflPjA4Nc+8CWVpZUGjtTkqRKG3rraNklqOIMU5IkSTm4zCepMG6DoLb1gz979+e+35z2Eo+S0XzZmZIkScrBMCVJkpSDy3yS5sUlvc7grujTyLDkp2KMDwwCVP6pPsOUJM3CrRAkzcUwJUldxm7Vezl4rrycmZIkSfN2YfPObmZnStKcum0+yqW9anCzTrWKYUqSMEBJmj+X+SRJknKwMyVJqpzMS3w/+DN468fvvv7Q325OQaq0TJ2piLgtIl6PiOMR8dA0n/9BRLwaEUcj4k8jwr+NkiSpK8zZmYqIBcBjwK3AKFCLiOGU0qsNl70CrE4p/TQifh/4KnBnMwqW1FzdNmwuSXllWea7GTieUhoBiIingDuAi2EqpfRiw/UHgd8tskhJKpoD5+o98GN+uPZvlV2GKiDLMt/1wImG16OT783kHuD56T6IiPsi4lBEHBofH89epSRJTdB74MdzXyTNodAB9Ij4XWA18PHpPk8pPQE8AbB69epU5L0lSfPnruiT3vqrd392GL0w4wODlT6fL0uYehNY2vC6Z/K994iItcAjwMdTSu8UU56kZnI+SpLyy7LMVwNujIi+iLgKuAsYbrwgIv4u8K+BjSmlnxRfpiRJUnuaszOVUjoXEVuAF4AFwDdTSsciYhtwKKU0DHwN+JvAMxEB8EZKaWMT65Yk6RIeIaMyZJqZSintA/ZNee/Rhp/XFlyXJBXOJ/ik5rhw2PGa69aUXEk53AFdkjQth9KlbAxTkirNbpTUHqr8RJ9hSuoSPrknXSa3SVBGmc7mkySp3Tl8rrLYmZIqyC6UNDN3PVfRDFOSJM2lcckPXPbTeximJFWKA+dSeWpjta7cHsEwJanjGaBax+0SpEs5gC5JkpSDYUqSJCkHl/mkDtetT+65tCd1nvGBQYDKbd5pZ0qSJCkHw5QkSVIOLvNJHaRbl/Skubj7ucpkmJLUEZyRal9ul6Bu5zKfJKlreJSMmsEwJUmSClMbq1Ebq5VdRku5zCdJqrzCO1KNZ/V5Tl/XM0xJbcphc2luDp6rHRimpDZgcJqeQ+fqCI1dKrBT1YUMU1KLGZzUDXzCTxfmptZct+aSz8YHBiu1C7phSlJbsRslqdMYpqQmsgslSdVnmJJUKjtRaraW7y3lk35dx32mJEmScrAzJRXEJT1pdkUPpWfZFsEdz9UKhilJLefSnqQqMUxJktQszk/NaHxgEKASWyQYpqQG0y3Vff7WFSVUImkm7nqudmOYkubgLJQkzd9sm3dWhWFKXcuQ1FrOSUmaThV2QzdMSWoKw5OyaNaxMz7Fp1YyTKkr2IWSOsdsAauj56U8ELmy3LRTkiQpBztTqhy7UOVxaU9SNzJMqaMZnMpngFK7cV6q83T6nlOGKUlS2+voWSlVnmFKHcMuVHuwE6UynHjr/13y3tIP/Y0SKimQu6NXhmFKLZV1h3GDU3sxQEnKqzZWq+zGnYYplc7gJEmCzt3A0zAlaVp2o9RpOnrwvEuW/Kp6tIxhShJgeJKk+TJMqRAu1UlqluH3HZ/2/alD6b989hwfWOj/ran1/Funy2ZwktRufu2//zUA/+fsuUs+67iA1eXHznTi3FSH/Q1TqxmcJElFq9qTfYYpXWRw6g7ORqlTzLS8d7kq0a1SW/NvU5cyOHUPw5Oq6sLSnjrTbE/2ddrxMoapLmBw6j4GKGl2HdWtmjpDdUFFZqmqsOTXpn9zNF8Gp+5lgFJVFLW8J7WKYapDGJI0leFJ3awZS3wd1a2CSj31N9OSX6c82Zfpb0lE3Ab8MbAA+DcppT+a8vkvAd8G/h5wErgzpfTDYkuVJHW7Vs9JTRewptPWoUtNN+e3HxELgMeAW4FRoBYRwymlVxsuuwc4nVJaHhF3AV8B7mxGwVVjx0lzsQMlKZMKzFbNNj/Vzl2qLFH6ZuB4SmkEICKeAu4AGsPUHcCXJn/+D8BgRERKKRVYa8czOKlRY0g6eMN9074vdYvZ5qQ64am9jlsibGNTA9WFJ/vaWZZv+nrgRMPrUeCjM12TUjoXEW8DS4D2/zfgMhmINJv5BiEDlLrJXAPmnRCessi6RJhV1nB2yX3H/jJ/sGtxd6txhqrx58Zg1U5dqpbG5oi4D7jwn+D/NyJeb+X928w1VDBsdim/y2rwe6wOv8vK+HbDd/nt93704AOtLmbGRJklTL0JLG143TP53nTXjEbEFcAHmRhEf4+U0hOA/wkORMShlNLqsutQfn6X1eD3WB1+l9XRKd/l+zJcUwNujIi+iLgKuAsYnnLNMHD35M+bgP/ivJQkSeoGc3amJmegtgAvMLE1wjdTSsciYhtwKKU0DHwD+JOIOA6cYiJwSZIkVV6mmamU0j5g35T3Hm34+Szw28WWVnkud1aH32U1+D1Wh99ldXTEdxmuxkmSJM1flpkpSZIkzcAwVaKI6I+IgxFRj4hDEXFz2TVpfiLigYj4XxFxLCK+WnY9yicivhARKSKuKbsWzU9EfG3y38mjEbEnIj5Udk3KLiJui4jXI+J4RDxUdj1zMUyV66vAv0wp9QOPTr5Wh4mITzBxCsCvpZRWAjtKLkk5RMRSYB3wRtm1KJfvAr+aUvo7wPeBh0uuRxk1HGP3KeAjwOaI+Ei5Vc3OMFWuBHxg8ucPAj8qsRbN3+8Df5RSegcgpfSTkutRPruAf8bEv5/qUCml/SmlC1uBH2Rij0R1hovH2KWUfgZcOMaubRmmyvVPgK9FxAkmuhn+l1NnWgH8ZkS8HBH/NSKmP6VTbS8i7gDeTCn9Rdm1qFD/CHi+7CKU2XTH2F1fUi2ZeApjk0XEAeC6aT56BPgk8PmU0n+MiN9hYr+uta2sT9nM8T1eAfwy8DFgDfB0RCxz49r2NMd3+c+ZWOJTB5jtu0wp/afJax4BzgFPtrI2dRe3RijR5IHQH0oppYgI4O2U0gfm+nNqLxHxn4GvpJRenHz9l8DHUkrj5VamyxERq4A/BX46+VYPE0vvN6eUxkorTPMWEb8H/GPgkymln85xudpERPw68KWU0m9Nvn4YIKW0vdTCZuEyX7l+BHx88ue/D/zvEmvR/D0HfAIgIlYAV+Ehqx0npfQ/Ukq/klLqTSn1MrG0cJNBqjNFxG1MzL5tNEh1nCzH2LUVl/nKdS/wx5OHQ58F7iu5Hs3PN4FvRsT/BH4G3O0Sn1S6QeCXgO9ONP45mFK6v9ySlMVMx9iVXNasXOaTJEnKwWU+SZKkHAxTkiRJORimJEmScjBMSZIk5WCYkiRJysEwJUmSlINhSpIkKQfDlCRJUg7/H3E6s99vVsI1AAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 720x360 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.figure(figsize=(10, 5))\n",
-    "for i in range(4):\n",
-    "    s = samples[\"theta\"][:, i]\n",
-    "    s = s[jnp.newaxis]\n",
-    "    plt.hist(s, bins=100, density=True, label=f\"$\\\\theta_{i}$\", alpha=0.5)\n",
-    "plt.legend()\n",
-    "None\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "$ P(x_i | x_{-i}, y, \\theta) = P(x, y, \\theta) / P(x_{-i}, \\theta, y) $"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "2) gaussian approx at x=mu(theta)\n",
-    "\n",
-    "* p_thetaIy = log_berry_likelihood(vars) - p_x_I_theta_y  \n",
-    "\n",
-    "* Note the last term depends on a fixed theta too\n",
-    "\n",
-    "2) p_thetaIy = log_berry_likelihood(vars) - .5 * log(-H(f(x_0)))  \n",
-    "\n",
-    "3) p_xiIy = sum(p_xiItheta_y + p_thetaIy for theta in thetas)\n",
-    "\n",
-    "* times dTheta\n",
-    "\n",
-    "* p_xiItheta_y is skew normal approximation at MAP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "$ P(t|y) = P(x, t, y) / gaussian(P(x | t, y)) $\n",
-    "\n",
-    "$ P(x_i|t,y) = P(x, t, y) / gaussian(P(x-i|t,y)) $\n",
-    "\n",
-    "$ P(x_i | y) = \\sum(P(xi|t,y) * P(t|y) \\Delta t) $\n",
-    "\n",
-    "$ P(x_i | y) = \\sum(P(xi|t,y) * P(t|y) \\Delta t) $"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(6,)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[-1.03994812e+02,  0.00000000e+00,  0.00000000e+00,\n",
-       "               0.00000000e+00,  1.00000000e+02,  9.65321387e+03],\n",
-       "             [ 0.00000000e+00, -1.04937164e+02,  0.00000000e+00,\n",
-       "               0.00000000e+00,  1.00000000e+02,  2.25158911e+03],\n",
-       "             [ 0.00000000e+00,  0.00000000e+00, -1.07928795e+02,\n",
-       "               0.00000000e+00,  1.00000000e+02,  6.33029883e+03],\n",
-       "             [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,\n",
-       "              -1.08560623e+02,  1.00000000e+02,  2.96381812e+03],\n",
-       "             [ 1.00000000e+02,  1.00000000e+02,  1.00000000e+02,\n",
-       "               1.00000000e+02, -4.00010010e+02, -2.11989219e+04],\n",
-       "             [ 9.65321289e+03,  2.25158911e+03,  6.33029883e+03,\n",
-       "               2.96381812e+03, -2.11989180e+04, -1.44111600e+06]],            dtype=float32)"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "y = Y_I2[-1]\n",
-    "n = N_I2[-1]\n",
-    "log_berry_likelihood = get_log_berry_likelihood(y, n)\n",
-    "grad = jax.grad(log_berry_likelihood, 0)\n",
-    "hess = jax.jacobian(grad)\n",
-    "# theta = jnp.zeros(4)\n",
-    "key = jax.random.PRNGKey(0)\n",
-    "theta = jax.random.uniform(key, [4])\n",
-    "mu = jnp.zeros(1)\n",
-    "sigma = jnp.array(0.01)[jnp.newaxis]\n",
-    "vars = jnp.concatenate([theta, mu, sigma])\n",
-    "print(vars.shape)\n",
-    "jnp.exp(log_berry_likelihood(vars))\n",
-    "grad(vars)\n",
-    "h = hess(vars)\n",
-    "h\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "N_ARMS = 4\n",
-    "\n",
-    "\n",
-    "def pack_vars(theta, mu, sigma):\n",
-    "    return jnp.concatenate([theta, mu, sigma])\n",
-    "\n",
-    "\n",
-    "def unpack_vars(vars):\n",
-    "    return vars[:N_ARMS], vars[N_ARMS], vars[N_ARMS + 1]\n",
-    "\n",
-    "\n",
-    "# print(hs.shape)\n",
-    "@jax.jit\n",
-    "def chol():\n",
-    "    hs = jnp.stack([h for i in range(4 * 16)])\n",
-    "    return jax.lax.linalg.cholesky(\n",
-    "        hs,\n",
-    "    )\n",
-    "    # return jnp.linalg.inv(hs)\n",
-    "\n",
-    "\n",
-    "# %timeit chol()\n",
-    "\n",
-    "# @jax.jit\n",
-    "def optimize(theta, sigma, mask):\n",
-    "    log_berry_likelihood = get_log_berry_likelihood(y, n)\n",
-    "    grad = jax.grad(log_berry_likelihood, 0)\n",
-    "    hess = jax.jacobian(grad)\n",
-    "    # theta = jnp.zeros(4)\n",
-    "    mu = jnp.zeros(1)\n",
-    "    sigma = jnp.array(sigma)[jnp.newaxis]\n",
-    "    vars = pack_vars(theta, mu, sigma)\n",
-    "    # Do a newton iteration\n",
-    "    pvars = None\n",
-    "    for _ in range(10):\n",
-    "        g = grad(vars)\n",
-    "        h = hess(vars)\n",
-    "        g = g[mask]\n",
-    "        h = h[mask, mask]\n",
-    "        pvars = vars\n",
-    "        print(jnp.diag(h))\n",
-    "        update = jnp.linalg.solve(h, g)\n",
-    "        vars = vars.at[mask].add(-update)\n",
-    "        # assert not jnp.isnan(vars).any()\n",
-    "        # print(jnp.linalg.norm(pvars - vars))\n",
-    "    return vars\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000001e+08 -1.0000001e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n",
-      "[-1.0000000e+08 -1.0000000e+08 -1.0000001e+08 -1.0000001e+08\n",
-      " -4.0000000e+08]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([-1.5039762e+00, -1.5039762e+00, -1.5039762e+00,\n",
-       "             -1.5039761e+00, -1.5039762e+00,  9.9999999e-09],            dtype=float32)"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "theta = jnp.zeros(4)\n",
-    "sigma = 1e-8\n",
-    "mask = jnp.s_[0:5]\n",
-    "optimize(theta, sigma, mask)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sigmas = jnp.power(10, jnp.linspace(-8, 3, 10))\n",
-    "thetas = jnp.linspace(-10, 10, 10)\n",
-    "mask = jnp.s_[1:5]\n",
-    "varss = []\n",
-    "for sigma in sigmas:\n",
-    "    for theta in thetas:\n",
-    "        theta = jnp.zeros(4).at[0].set(theta)\n",
-    "        vars = optimize(theta, sigma, mask)\n",
-    "        varss.append(vars)\n",
-    "varss = jnp.stack(varss)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100, 6)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "varss.shape\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x1683349a0>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAfgUlEQVR4nO3dfZBcdZ3v8fc3kxkcUDNAAphJYrKI1AUSiPQGreCqgDx6TTarEbb04roasUQvWxbcIFu5QF0rkbhSKO6yucgt9YrALiaggOHJWl2qYDMhyDMrT1ky4WGQJOBmIJnku390TzLT0z3DZPqc8+35fV5Vqen+9Znpz0yS853zezrm7oiISLomFB1ARESKpUIgIpI4FQIRkcSpEIiIJE6FQEQkcROLDrAvJk+e7DNnziw6hohIU1m/fv2r7j6lur0pC8HMmTPp6uoqOoaISFMxs4212tU1JCKSOBUCEZHEqRCIiCROhUBEJHEqBCIiiWvIrCEzuw74BPCKux9TaTsIuBGYCTwPLHb3LTU+91zgbytP/4+7/6gRmaqt2dDNyrVPsXlrL1M72rnwtCNZOLczi7dSjibKICJgjdh91Mz+DPgj8OMBheAK4DV3X2FmS4ED3f1/VX3eQUAXUAIcWA8cX6tgDFQqlXw000fXbOjm4p8/Qu/OXXva2ltbWL5odq4nHuWIlWFgFhUkSYGZrXf3UnV7Q7qG3P03wGtVzQuA/t/ufwQsrPGppwF3uftrlZP/XcDpjcg00Mq1Tw064QD07tzFyrVPNfqtlKOJMsDegtS9tRcHurf2cvHPH2HNhu5cc4gUKcsxgkPd/cXK45eAQ2sc0wm8MOD5pkrbEGa2xMy6zKyrp6dnVEE2b+0dVXtWlCNWBohTkESKlMtgsZf7n8bUB+Xuq9y95O6lKVOGrJAe1tSO9lG1Z0U5YmWAOAVJpEhZFoKXzew9AJWPr9Q4phuYPuD5tEpbQ1142pG0t7YMamtvbeHC045s9FspRxNlgDgFSaRIWRaCW4FzK4/PBW6pccxa4FQzO9DMDgROrbQ11MK5nSxfNJvOjnYM6OxoL2RQUjliZYA4BUmkSI2aNfQz4KPAZOBl4H8Da4CbgBnARsrTR18zsxJwnrt/sfK5XwC+WflS33L3/zfS+4121pDIcDRrSFJRb9ZQQwpB3lQIRERGr14haMptqEXGI12ZSFFUCEQCqF5g17+eAVAxkMxpryGRALSeQYqkQiASgNYzSJFUCEQC0HoGKZIKgUgAWs8gRdJgsUgA/QPCmjUkRVAhEAli4dxOnfilEOoaEhFJnAqBiEjiVAhERBKnQiAikjgVAhGRxCUzayjKhl7KESuDiCRSCKJs6KUcsTIMzKKCJClLomsoyoZeyhErA+wtSN1be3H2FqQ1Gxp+x1SRsDItBGZ2pJk9NODP62Z2QdUxHzWzbQOOWdboHFE29FKOWBkgTkESKVKmXUPu/hRwHICZtVC+Mf3qGof+1t0/kVWOqR3tdNc4weS9oZdyxMoAcQqSSJHy7Bo6GXjG3Tfm+J5AnA29lCNWBtCunyKQbyE4G/hZndc+ZGa/M7M7zOzoWgeY2RIz6zKzrp6enlG98cK5nSxfNJvOjnYM6OxoZ/mi2bkPCCpHrAwQpyCJFCmXm9ebWRuwGTja3V+ueu3dwG53/6OZnQlc5e5HDPf1dPN6aSTNGpJUFH3z+jOAB6uLAIC7vz7g8e1m9vdmNtndX80pmyROu35K6vIqBOdQp1vIzA4DXnZ3N7N5lLur/pBTLpEwdGUiRcm8EJjZAcDHgS8PaDsPwN2vAT4FfMXM+oBe4GzPo79KJJBIC+wkPZkXAnf/T+DgqrZrBjy+Grg66xwikQ23nkGFQLKWxMpikei0nkGKpEIgEoDWM0iRVAhEAtB6BilSEruPikTXPw6gWUNSBBUCkSC0nkGKoq4hEZHEqRCIiCROhUBEJHEqBCIiiVMhEBFJXDKzhqJs6KUcsTKISCKFIMqGXsoRK8PALCpIkrIkuoai3KBcOWJlgL0FqXtrL87egrRmQ3euOUSKlEQhiLKhl3LEygBxCpJIkZIoBFE29FKOWBkgTkESKVIShSDKhl7KESsDxClIEtTDN8GVx8ClHeWPD980LnNkXgjM7Hkze8TMHjKzIXect7LvmdnTZvawmX2g0RkWzu1k+aLZdHa0Y0BnRzvLF83OfUBQOWJlgDgFSWoo+iT88E3wi6/DthcAL3/8xdfHZQ7L+q6QZvY8UKp3M3ozOxP4GnAmcAJwlbufMNzXLJVK3tU1pKaI7BPNGgqo/+S3c0AXXWs7/PfvwZzF+WS48pjKybfKpOnwN4/mk6HBOcxsvbuXqtsjTB9dAPy4cp/i+82sw8ze4+4vFh1M0qBdPwO65/LBRQDKz++5PL9CsG3T6NqbOEceYwQO3Glm681sSY3XO4GB5W5TpW0QM1tiZl1m1tXT05NRVJHirNnQzfwV9zJr6W3MX3Fv2lNYI5yEJ00bXXsT58ijEJzo7h8AzgC+amZ/ti9fxN1XuXvJ3UtTpkxpbEKRgmk9Q5UIJ+GTl5W7owZqbS+35ymHHJkXAnfvrnx8BVgNzKs6pBuYPuD5tEqbSDK0nqFKhJPwnMXlMYlJ0wErf8xzjCLHHJmOEZjZAcAEd3+j8vhU4PKqw24FzjezGygPFm/T+ICkRusZqvSf5O65vNwdNGlauQgUcRLO+z0LyJH1YPGhwGoz63+v6939V2Z2HoC7XwPcTnnG0NPAduCvMs4kEs7Ujna6a5z0k17PEOUknIBMC4G7PwscW6P9mgGPHfhqljlEorvwtCMHbcIHBa5nePim4n8TjyLKzyLjHBGmj4okr3/6auHrGarn7/cvXoL0ikGUn0UOOTJfUJYFLSgTyUiURVRQ/G/jUX4WiSwoE5EoIszfhxi/jUf5WYyTBWUi0iwizN+H4VcW5yXKz2KcLCgTkWYRYf4+xPht/IhTR9fexDlUCERkryiLqNoPHF17Fn5/5+jamziHxghEZDDN3y+LcFWSU45kCkGUrYaVI1YGqaHo2ToAvVtG156FSdPqzNYpYIwg4xxJdA1F2dBLOWJlGJhFu35WRLkZS4SB2pOXwYTWwW0TWovZdC7jHEkUgigbeilHrAwQqyCFEGG2DsQZtC5vj1P/+TjJkUQhiLKhl3LEygBxClIYUfrF5yyGY/8SrHIbUWspP8+zi+qey2HXjsFtu3bkXxRzyJFEIYhyg3LliJUB4hSkMCJ0yUC5K+p314NXirTvKj/Ps4sqSlHUgrLGiHKDcuWIlQHiFKQwonTJROiiilIUtaCsMRbO7WT5otl0drRjQGdHO8sXzc59hopyxMoAcQpSGHMWs272ZbzEFHa78RJTWDf7svxnDUX4bfzkZdDSNritpa2YweKMcyQzfTTKDcqVI14GCLDrZxBrNnRz8br30rvzqj1t7etaWD69O9+fSfuB0Pta7fY8VW/KWdQmnRnnyKwQmNl04MeUb07jwCp3v6rqmI8CtwDPVZp+7u45j8RI6iIUJIixrmLl2qf4+K5/4aK2m5hqr7LZJ3NF32JWrm0L8TPK1T2Xw+6dg9t27yy35z1onXGOLK8I+oBvuPuDZvYuYL2Z3eXuj1cd91t3/0SGOUTC65/G2j+DqX8aK5DrCbj0+l2sbF1Fm/UBMM1e5Tutq7jwdYCTcssRYkFZhO6pnHJkNkbg7i+6+4OVx28ATwCJ/Uoh8vZEmcZ6WdtP9hSBfm3Wx2VtP8k1R4iB2ggZcsqRy2Cxmc0E5gIP1Hj5Q2b2OzO7w8yOHuZrLDGzLjPr6unpySqqSCGiTGOdxBujas9MhNlL2n20cczsncDNwAXu/nrVyw8C73X3Y4HvA2vqfR13X+XuJXcvTZkyJbO8IkWIMo213nrV3NfTRlhQltDuo5kWAjNrpVwEfuruP69+3d1fd/c/Vh7fDrSa2eQsM4lEFGYaa/tBo2vPihaU5Zojs0JgZgb8EHjC3b9b55jDKsdhZvMqef6QVSaRqKKsq3jmkFNrzlR85pCcu0O0oCzXHFnOGpoPfA54xMweqrR9E5gB4O7XAJ8CvmJmfUAvcLZ7URN1RYoVYRrrARvvqbm/2QEb78k3SITfxk9eBrd8dfA+P0UtKMs4R2aFwN3/lRG6Ft39auDqrDKIyOgc4j01/9ce4q/mG0QLynLNkcQWEyLy9rxu76rT/s6ckwQw3EKucZZDhUBE9qgesB6pPTNaUJZrDhUCEdljv53bRtWele3th42qPRMJDRarEIjIXvX64HPum79i52d4ywdfhbzlLVyx8zP5hTjiVKp74r3SnqvxsKBMRGS0tmzfgVWNWhvGlu076nxG421/7PYh4+ZWac9VDgvKktmGOsLOjsoRL0OkHBF475aaU/3qtWfl4rZ/oo2hex5d3PZPwPJcMryj96VRtWfFt22q/XdSp31fJFEIouzsqByxMkTKEcXLTOYwhu7lVW7Pz6HUnq5arz0LW/0ADrI/1m7PLQVs45101NjrqdzeGEl0DUXZ2VE5YmWIlCOK5Ts+XbNvfvmOT+eaw+qMSdRrz8KE6pV1I7RnZdfu2msG6rXviyQKQZSdHZUjVoZIOaI4cP+2mn3zB+7fVuczsvFW365RtWdhEkOvBoZrz8qBE/5zVO37IolCEGVnR+WIlSFSjiguar2x5v0ILmq9MdccrTurNyoevj0LEa5KAHa2vntU7fsiiUIQZWdH5YiVIVIOKI9XzF9xL7OW3sb8FfeyZkN37hn2731xVO1Z2bL7gFG1Z+Gtvt2jas9O9puDJzFYHOUG5coRK0OkHGs2dDN59WL+1R6F/YBeuG/1MazhpnyzWMverZ+r23PUMqH2Sa5eexZa6yyiq9fezDmsGTf7LJVK3tXVVXQMkYZ54NIPM88fHrTzpzv8m83hhEt/m1+QSycN81p+J0C/tAMbspwLHMMu3ZpLhk3LDmfahKGzlDbtnsy0y5/JJUOjc5jZencvVbcn0TUkEl11EYDy9s/z/OFcc2xvf8+o2rNidbZPqNeehWvbPst2HzxIvt3buLbts7llyCuHCoFIBEHuEXnHm8fW3PH4jjePzTXHusO/Rm/Vya/X21h3+Ndyy3DcWUu4ZNeX2LR7Mrvd2LR7Mpfs+hLHnbUktwz9OZb5kkE5lvmShuZIYoxARN6eE3Z1YVW/HpqV2/N0weNHcPzOL3LRxJuYan9gsx/MFX2LWf/4Edz3yfxy/HL3iazum7/neesE4yP5vT1QHsfq2ng2H3lgPrvcaTHjnBOmN3TsKPNCYGanA1cBLcC17r6i6vX9gB8Dx1O+TeVn3P35hgep1feZY5+ncgTNECRHkAsCpk6ofafYeu1Z2by1l25O5NYdJw5qtxzXd6xc+xQ7qxZt7dztrFz7VO6r329e382uyqXaLnduXt9N6b0HNSxH1jevbwF+AJwBHAWcY2ZHVR3218AWd38fcCXw7YYHqTcANtzAWBaUI1aGSDmCeLPONs/12rMSYX1HlMWGeax+z3qMYB7wtLs/6+47gBuABVXHLAB+VHn8z8DJ/Te0F5F87X/G5fS1vGNQW1/LO9j/jHzvyhVhfUeEYgT5FKSsC0En8MKA55sqbTWPcfc+YBtwcPUXMrMlZtZlZl09PUM3xRKRBpizmIkLvg+TpgMGk6aXn89ZnGuMhXM7+YvjO2mp/E7YYsZfHN+Za5dMhGIE+RSkppk15O6r3L3k7qUpU6YUHUeksSbUGa6r156hNbvmM/+t7zHrzZ8y/63vsWbX/JE/qdEZ6vSL57naOkIxgnJBam0Z3EnS2mINLUhZF4JuYPqA59MqbTWPMbOJwCTKg8Yi6Vj4DwwdGrZKe376t+Xu3tqLs3db7ry3u4iwK2yEYrRHzVulNU7WhWAdcISZzTKzNuBs4NaqY24Fzq08/hRwrzd6uXO9GSC5z5JRjlAZIuWYsxgWrRrUJcOiVbl3yUQ4AUOMgdooP4vhZi81SqbXne7eZ2bnA2spTx+9zt0fM7PLgS53vxX4IfATM3saeI1ysWi8IqYl1qIcsTJAnBxzFud+4q8W4QQM5f7v7hrvmeKsofEwWIy73+7u73f3w939W5W2ZZUigLu/6e6fdvf3ufs8d38260wiUluUmTJ59IuPJMrPQoPFIpKrKDNlgMz7xUcSoRjllUOFQET2WDi3k+WLZtPZ0Y4BnR3tLF80O/eZMnn0i78tBRejuu/b4BzJ7DW0ZkN34XvOK0e8DMox1MK5+U+RrBahfz7KFhN55EiiEPRPieufAdA/JQ7Ifc8Q5YiTQTnqZym6IGmwON8cSXQNRZoGphxxMijHUFHWEUQYq9Bg8TiTUmVvlhwRMijHUFEKUoRVvRGKUV45kigEKVX2ZskRIYNyDBWlIEVY1RuhGOWVI4lCkFJlb5YcETIox1BRClKEK5MIxSivHEkUgihT4pQjVgblGCpKQYpwZRKhGOWVwxq9rU8eSqWSd3Xle+s8kVREmDU0f8W9NWcNdXa0c9/Sk3LJMGvpbTWn6xvw3IqzcsnQ6Bxmtt7dS9XtSUwfFZG3L8I6ggtPO3LQdFooZtZQ0VNY88qRRNeQiDSXCAO1KW0xoSsCERkkQtdQHjdsf1sS2WJCVwQiskeUBWURBmqj7HeURw4VAhHZI8IJGGLMGoqQIa8cKgQiskeUk1+E9QwRMuSVI5NCYGYrzexJM3vYzFabWUed4543s0fM7CEz03xQkYJFOflFWM8QIUNeObK6IrgLOMbd5wD/Dlw8zLEfc/fjas1tFZF8RTn5RZg1FCFDXjkyKQTufqe791We3g9My+J9RKSxoqxwjrC9Q4QMeeXIfGWxmf0CuNHd/3+N154DtlCeDPWP7r5qmK+zBFgCMGPGjOM3btyYUWIRKVqElcURMjQ6R8NXFpvZ3cBhNV66xN1vqRxzCdAH/LTOlznR3bvN7BDgLjN70t1/U+vASpFYBeUtJvY1t4jEF2HQOkKGvHLscyFw91OGe93MPg98AjjZ61x2uHt35eMrZrYamAfULAQiko4I2ztEyJBXjqxmDZ0OXAR80t231znmADN7V/9j4FTg0SzyiDSDNRu6mb/iXmYtvY35K+7NvS86kgiD1tpiYuyuBvaj3N0DcL+7n2dmU4Fr3f1M4FBgdeX1icD17v6rjPKIhKZ7Fg+2cG4nXRtf42cPvMAu98Jm7KSyxUQmhcDd31enfTNwZuXxs8CxWbx/LRH+cStHvAxRcgy3ojfPLFEKUoS9hobb2iHPn0UeOZJYWRxl/xTliJUhUo4oA5NRtpiIkCPK34m2mGiQCP+olCNehkg5oqzoTenkN5IofydNu8VENBH+USlHvAyRckQYHIW0Tn4jifJ30sxbTIQS4R+VcsTLEClHlBW9KZ38RqItJsaZCP+olCNehkg5oPwf/r6lJ/HcirO4b+lJhQycRylIEU7CKW0xkcQdyvr/8RQ9M0Q5YmWIlCOSCPcsjjJrKMJMrjxyZL7XUBZKpZJ3dWnXapHxKsI+P7OW3lZzur4Bz604K5cMjc5Rb6+hJLqGRKS5RBjEjzJ+pFlDIpKkCCfhKONHmjUkIkmKcBKONHCedQ6NEYjIIBG23IiUYzxp+P0IRGT8ibLXUP/76cSfD3UNicgeUbbckHypEIjIHhFm60j+VAhEZI8Is3Ukf5kVAjO71My6zeyhyp8z6xx3upk9ZWZPm9nSrPKIyMgizNaR/GU9WHylu3+n3otm1gL8APg4sAlYZ2a3uvvjGecSkRq05Uaaip41NA94unK3MszsBmABoEIgUhDN1klP1oXgfDP7H0AX8A1331L1eifwwoDnm4ATan0hM1sCLAGYMWNGBlFFiqV581KUMY0RmNndZvZojT8LgH8ADgeOA14E/m4s7+Xuq9y95O6lKVOmjOVLiYQT5ZaZkqYxXRG4+ylv5zgz+7/AL2u81A1MH/B8WqVNJClRtjyWNGXWNWRm73H3FytP/xx4tMZh64AjzGwW5QJwNvCXWeSJctmtHLEyRMmh+ftSpCzHCK4ws+MAB54HvgxgZlOBa939THfvM7PzgbVAC3Cduz/W6CBRls0rR6wMkXJM7Wivuf++5u9LHjJbR+Dun3P32e4+x90/2X914O6b3f3MAcfd7u7vd/fD3f1bWWSJsmxeOWJliJRD8/elSEVPH81FlMtu5YiVIVIOzd+XIiVRCKJcditHrAyRckCc+fsRxkwkX0nsNRTlsls5YmWIlCMKTWNNUxJXBFEuu5UjVoZIOaLQNNY06Q5lIrLHrKW3UeuMYMBzK87KO440WL07lCXRNSQib4+2oU6TCoGI7KExkzQlMUYgIm+PxkzSpEIgIoNEmcYq+VHXkIhI4lQIREQSp0IgIpI4FQIRkcSpEIiIJE6FQEQkcSoEIiKJy2QdgZndCPQvRewAtrr7cTWOex54A9gF9NXaA0MkFdr+WYqSSSFw98/0PzazvwO2DXP4x9z91SxyiDSLKLfMlDRl2jVkZgYsBn6W5fuINLsot8yUNGW9xcSHgZfd/fd1XnfgTjNz4B/dfVW9L2RmS4AlADNmzBh1kCiX3coRK0OUHFFumSlp2udCYGZ3A4fVeOkSd7+l8vgchr8aONHdu83sEOAuM3vS3X9T68BKkVgF5fsRjCZrlMtu5YiVIVKOSLfMlPTsc9eQu5/i7sfU+HMLgJlNBBYBNw7zNborH18BVgPz9jXPcKJcditHrAyRcmj7ZylSlmMEpwBPuvumWi+a2QFm9q7+x8CpwKNZBIly2a0csTJEyrFwbifLF82ms6MdAzo72lm+aLYGiiUXWY4RnE1Vt5CZTQWudfczgUOB1eXxZCYC17v7r7IIEuWyWzliZYiUA7T9sxQnsysCd/+8u19T1ba5UgRw92fd/djKn6Pd/VtZZYly2a0csTJEyiFSpCRuTBPlrkvKEStDpBwiRTL3UU3ACaFUKnlXV1fRMUREmoqZra+1g4P2GhIRSZwKgYhI4lQIREQSp0IgIpI4FQIRkcSpEIiIJE6FQEQkcSoEIiKJUyEQEUmcCoGISOJUCEREEpfEpnMizSDCLTMlTSoEIgFEuWWmpEldQyIBRLllpqRpTFcEZvZp4FLgvwHz3L1rwGsXA38N7AK+7u5ra3z+LOAG4GBgPfA5d98xlkz1RLnsVo5YGaLkiHLLTEnTWK8IHqV8g/rfDGw0s6Mo36ryaOB04O/NrGXop/Nt4Ep3fx+whXLhaLj+y+7urb04ey+712zozuLtlKNJMkTKUe/WmEXcMlPSM6ZC4O5PuHuta9cFwA3u/pa7Pwc8DcwbeICVb1Z8EvDPlaYfAQvHkqeeKJfdyhErQ6QcumWmFCmrMYJO4IUBzzdV2gY6GNjq7n3DHLOHmS0xsy4z6+rp6RlVmCiX3coRK0OkHAvndrJ80Ww6O9oxoLOjneWLZmugWHIx4hiBmd0NHFbjpUvc/ZbGR6rN3VcBq6B8q8rRfO7Ujna6a/zHzvuyWzliZYiUA8rFQCd+KcKIVwTufoq7H1Pjz3BFoBuYPuD5tErbQH8AOsxs4jDHNESUy27liJUhUg6RImW1juBW4Hoz+y4wFTgC+LeBB7i7m9mvgU9Rnjl0LpDJFUb/b1lFzwxRjlgZIuUQKZK5j6qXZfAnm/058H1gCrAVeMjdT6u8dgnwBaAPuMDd76i03w580d03m9mfUC4CBwEbgM+6+1sjvW+pVPKurq6RDhMRkQHMbL27l4a0j6UQFEWFQERk9OoVAq0sFhFJnAqBiEjiVAhERBKnQiAikrimHCw2sx5g4z5++mTg1QbGiWQ8f28wvr8/fW/Nq5m+v/e6+5TqxqYsBGNhZl21Rs3Hg/H8vcH4/v70vTWv8fD9qWtIRCRxKgQiIolLsRCsKjpAhsbz9wbj+/vT99a8mv77S26MQEREBkvxikBERAZQIRARSVyShcDMjjOz+83socpdz+aN/FnNw8y+ZmZPmtljZnZF0Xkazcy+YWZuZpOLztJIZray8vf2sJmtNrOOojONlZmdbmZPmdnTZra06DyNYmbTzezXZvZ45f/Z/yw601gkWQiAK4DL3P04YFnl+bhgZh+jfM/oY939aOA7BUdqKDObDpwK/EfRWTJwF3CMu88B/h24uOA8Y2JmLcAPgDOAo4BzzOyoYlM1TB/wDXc/Cvgg8NVm/t5SLQQOvLvyeBKwucAsjfYVYEX/fR3c/ZWC8zTalcBFlP8OxxV3v3PAPbzvp3zXvmY2D3ja3Z919x2U7z2yoOBMDeHuL7r7g5XHbwBPMMw916NLtRBcAKw0sxco/8bc1L95VXk/8GEze8DM/sXM/rToQI1iZguAbnf/XdFZcvAF4I6iQ4xRJ/DCgOebaOKTZT1mNhOYCzxQcJR9ltWtKgtnZncDh9V46RLgZOBv3P1mM1sM/BA4Jc98YzHC9zaR8h3fPgj8KXCTmf2JN8k84RG+t29S7hZqWsN9f/33Aa/c3a8P+Gme2WT0zOydwM2U78L4etF59lWS6wjMbBvQUblvsgHb3P3dI31eMzCzXwHfdvdfV54/A3zQ3XuKTTY2ZjYbuAfYXmmaRrlLb567v1RYsAYzs88DXwZOdvftIxwempl9CLh0wO1rLwZw9+WFBmsQM2sFfgmsdffvFp1nLFLtGtoMfKTy+CTg9wVmabQ1wMcAzOz9QBvNszNiXe7+iLsf4u4z3X0m5W6GD4yzInA65fGPTzZ7EahYBxxhZrPMrA04G7i14EwNUfkF8ofAE81eBGAcdw2N4EvAVWY2EXgTWFJwnka6DrjOzB4FdgDnNku3kHA1sB9wV/k8w/3ufl6xkfadu/eZ2fnAWqAFuM7dHys4VqPMBz4HPGJmD1XavunutxcXad8l2TUkIiJ7pdo1JCIiFSoEIiKJUyEQEUmcCoGISOJUCEREEqdCICKSOBUCEZHE/Rd0J8TsH9lx7gAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "sigmas = jnp.log10(varss[:, N_ARMS + 1])\n",
-    "thetas = varss[:, :N_ARMS]\n",
-    "plt.scatter(sigmas, jnp.mean(thetas, 1))\n",
-    "plt.scatter(sigmas, jnp.std(thetas, 1))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x29596a520>"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAD4CAYAAAAUymoqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAeyUlEQVR4nO3df3Dc9X3n8eerwhBBfojYOET+cRDI6KDGjumOSxvASc1YxvXEjnPX0KMEzhSXK7mDGyIO4RnaKVNSqmtpbyjN+OzcXVuuyTXIJk2gsklS0hnOvsj4h0xsGQiUeA2xIShp8E4jK+/74/uRuxa7kr7elWRJr8eMx9rP572f/Xy/Wuvl7+ez2lVEYGZmlsfPTfQEzMxs8nF4mJlZbg4PMzPLzeFhZma5OTzMzCy3syZ6AuNl1qxZcdFFF030NMzMJo1du3a9EREXVOqbNuFx0UUX0d3dPdHTMDObNCT9Y7U+L1uZmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5TZtXm1lZjadbN1dpKOrlyN9JZqbGmlrbWHN4jl1G9/hYWY2xWzdXaS9s4dS/wAAxb4S7Z09AHULEC9bmZlNMR1dvSeDY1Cpf4COrt66PYbDw8xsijnSV8rVfjpqCg9JHZIOStonaYukpip1d0raL+l5SXdV6L9bUkialW7fmMbskfSspEVltSsk9Up6UdK9tczfzGwqam5qzNV+Omq98tgOLIiIhcAhoH1ogaQFwG3AEmARsErSpWX984DlwKtld3sZWBoRVwAPABtTbQPwZ8D1wOXAr0u6vMZjMDObUtpaW2ic0XBKW+OMBtpaW+r2GDWFR0Rsi4gT6eYOYG6FssuAnRFxPNU+A6wt638YuAc4+Xm4EfFsRLxVYdwlwIsR8b2I+CnwJWB1LcdgZjbVrFk8h8+vvYI5TY0ImNPUyOfXXnHGvtpqHfDlCu37gd+XNBMoASuBbgBJq4FiROyVVG3cW4Gn0tdzgO+X9R0GfrHaHSWtB9YDzJ8/f9QHYmY22a1ZPKeuYTHUiOEh6WngwgpdGyLiiVSzATgBPDa0KCIOSHoI2Aa8DewBBiSdC9xHtmRV7bE/ThYeV494JBVExEbSklehUIgRys3MbJRGDI+IuG64fkm3AKuAZRFR8Qd0RGwGNqf6B8muGC4BLgYGrzrmAs9JWhIRr0taCGwCro+IN9NQRWBe2dBzU5uZmY2jmpatJK0g269YGhHHh6mbHRFHJc0n2++4KiL6gNllNa8AhYh4I9V1AjdFxKGyob4DfFjSxWShcQPw72o5BjMzy6/WPY9HgHOA7enqYUdE3C6pGdgUEStT3eNpz6MfuCMFx3DuB2YCj6ZxT0REISJOSPos0AU0AF+MiOdrPAYzM8tJVVaappxCoRD+JEEzs9GTtCsiCpX6/BvmZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWWz3fkt3MbNrburtIR1cvR/pKNDc10tbaMqZvjT5RHB5mZnWydXeR9s4eSv0DABT7SrR39gBMuQDxspWZWZ10dPWeDI5Bpf4BOrp6J2hGY8fhYWZWJ0f6SrnaJzOHh5lZnTQ3NeZqn8wcHmZmddLW2kLjjIZT2hpnNNDW2jJBMxo73jA3M6uTwU1xv9rKzMxyWbN4zpQMi6FqWraS1CHpoKR9krZIaqpSd6ek/ZKel3RXhf67JYWkWen2jWnMHknPSlqU2udJ+pak76ax7qxl/mZmdnpq3fPYDiyIiIXAIaB9aIGkBcBtwBJgEbBK0qVl/fOA5cCrZXd7GVgaEVcADwAbU/sJ4O6IuBy4CrhD0uU1HoOZmeVUU3hExLaIOJFu7gDmVii7DNgZEcdT7TPA2rL+h4F7gJMfph4Rz0bEW0PHjYjXIuK59PU/AQeAqX99aGZ2hqnnq63WAU9VaN8PXCNppqRzgZXAPABJq4FiROwdZtxbK40r6SJgMbCzxnmbmVlOI26YS3oauLBC14aIeCLVbCBbUnpsaFFEHJD0ELANeBvYAwykILmPbMmq2mN/nCw8rh7S/m7gceCuiPjxMPdfD6wHmD9/fvWDNDOzXBQRI1cNN4B0C/BbwLKIOD6K+geBw8A/AN8ABu8zFzgCLImI1yUtBLYA10fEobL7zwC+BnRFxB+Pdp6FQiG6u7tHW25mNu1J2hURhUp9Nb1UV9IKsv2KpcMFh6TZEXFU0nyy/Y6rIqIPmF1W8wpQiIg3Ul0ncNOQ4BCwGTiQJzjMzKy+at3zeAR4D7Bd0h5JXwCQ1CzpybK6xyV9F/hb4I4UHMO5H5gJPJrGHbxk+ChwE/ArqX2PpJU1HoOZmeVU87LVZOFlKzOzfIZbtvJ7W5mZWW4ODzMzy83hYWZmuTk8zMwsN4eHmZnl5rdkN7MpY+vu4rT4LI0zgcPDzKaErbuLtHf2UOofAKDYV6K9swfAATIGvGxlZlNCR1fvyeAYVOofoKOrd4JmNLU5PMxsSjjSV8rVbrVxeJjZlNDc1Jir3Wrj8DCzKaGttYXGGQ2ntDXOaKCttWWCZjS1ecPczKaEwU1xv9pqfDg8zGzKWLN4jsNinHjZyszMcnN4mJlZbg4PMzPLzeFhZma5OTzMzCy3msJDUoekg5L2SdoiqalK3Z2S9kt6XtJdFfrvlhSSZqXbN6YxeyQ9K2nRkPoGSbslfa2W+ZuZ2emp9cpjO7AgIhYCh4D2oQWSFgC3AUuARcAqSZeW9c8DlgOvlt3tZWBpRFwBPABsHDLsncCBGuduZmanqabwiIhtEXEi3dwBzK1QdhmwMyKOp9pngLVl/Q8D9wBRNu6zEfFWpXElzQV+FdhUy9zNzOz01XPPYx3wVIX2/cA1kmZKOhdYCcwDkLQaKEbE3mHGvXXIuH9CFjY/G2lCktZL6pbUfezYsdEdhZmZjWjE3zCX9DRwYYWuDRHxRKrZAJwAHhtaFBEHJD0EbAPeBvYAAylI7iNbsqr22B8nC4+r0+1VwNGI2CXpYyPNPSI2kpa8CoVCjFBuZmajNGJ4RMR1w/VLugVYBSyLiIo/oCNiM7A51T8IHAYuAS4G9kqCbGnqOUlLIuJ1SQvJlqauj4g301AfBT4haSXwLuC9kv4qIn5jxCM1M7O6qem9rSStIFtCWhoRx4epmx0RRyXNJ9vvuCoi+oDZZTWvAIWIeCPVdQI3RcShwZqIaCdtyqcrj885OMzMxl+tb4z4CHAOsD1dPeyIiNslNQObImJlqntc0kygH7gjBcdw7gdmAo+mcU9ERKHGuZqZWZ2oykrTlFMoFKK7u3uip2FmNmlI2lXtP+5+S3Yzq9nW3UV/jsY04/Aws5ps3V2kvbOHUv8AAMW+Eu2dPQAOkCnM721lZjXp6Oo9GRyDSv0DdHT1TtCMbDw4PMysJkf6SrnabWpweJhZTZqbGnO129Tg8DCzmrS1ttA4o+GUtsYZDbS1tkzQjGw8eMPczGoyuCnuV1tNLw4PM6vZmsVzHBbTjJetzMwsN4eHmZnl5vAwM7PcHB5mZpabw8PMzHJzeJiZWW4ODzMzy83hYWZmuTk8zMwst5rCQ1KHpIOS9knaIqmpSt2dkvZLel7SXRX675YUkmal2zemMXskPStpUVltk6SvpMc9IOmXajkGMzPLr9Yrj+3AgohYCBwC2ocWSFoA3AYsARYBqyRdWtY/D1gOvFp2t5eBpRFxBfAAsLGs70+Bv4uIf53GO1DjMZiZWU41hUdEbIuIE+nmDmBuhbLLgJ0RcTzVPgOsLet/GLgHOPlh6hHxbES8NXRcSe8DrgU2p7qfRkRfLcdgZmb51XPPYx3wVIX2/cA1kmZKOhdYCcwDkLQaKEbE3mHGvbVs3IuBY8D/kLRb0iZJ51W7o6T1kroldR87duw0DsnMzCoZMTwkPZ32K4b+WV1WswE4ATw29P4RcQB4CNgG/B2wBxhIQXIfcP8wj/1xsvD4L6npLOBK4M8jYjHwNnBvtftHxMaIKERE4YILLhjpUM3MbJRGfEv2iLhuuH5JtwCrgGUREZVqImIzaalJ0oPAYeASsiuJvZIgW5p6TtKSiHhd0kJgE3B9RLyZhjoMHI6Inen2VxgmPMymuq27i/4cDZsQNX2eh6QVZPsVSyPi+DB1syPiqKT5ZPsdV6W9itllNa8AhYh4I9V1AjdFxKHBmhQq35fUEhG9wDLgu7Ucg9lktXV3kfbOHkr9AwAU+0q0d/YAOEBszNW65/EI8B5gu6Q9kr4AIKlZ0pNldY9L+i7wt8Ado9jkvh+YCTyaxu0u6/uPwGOS9gEfAR6s8RjMJqWOrt6TwTGo1D9AR1fvBM3IppOarjwi4tIq7UfINsYHb18zirEuKvv6N4HfrFK3ByjknKrZlHOkr5Sr3aye/BvmZpNUc1NjrnazenJ4mE1Sba0tNM5oOKWtcUYDba0tEzQjm05qWrYys4kzuCnuV1vZRHB4mE1iaxbPcVjYhPCylZmZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluNYWHpA5JByXtk7RFUlOVujsl7Zf0vKS7KvTfLSkkzUq3b0xj9kh6VtKistr/nMbZL+mvJb2rlmMwM7P8ar3y2A4siIiFwCGgfWiBpAXAbcASYBGwStKlZf3zgOXAq2V3exlYGhFXAA8AG1PtHOA/AYWIWAA0ADfUeAxmuW3dXeSjf/BNLr7363z0D77J1t3FiZ6S2biqKTwiYltEnEg3dwBzK5RdBuyMiOOp9hlgbVn/w8A9QJSN+2xEvFVl3LOARklnAecCR2o5BrO8tu4u0t7ZQ7GvRADFvhLtnT0OEJtW6rnnsQ54qkL7fuAaSTMlnQusBOYBSFoNFCNi7zDj3jo4bkQUgf9KdpXyGvCjiNhWv0MwG1lHVy+l/oFT2kr9A3R09U7QjMzG34ifJCjpaeDCCl0bIuKJVLMBOAE8NrQoIg5IegjYBrwN7AEGUpDcR7ZkVe2xP04WHlen2+cDq4GLgT7gbyT9RkT8VZX7rwfWA8yfP3+kQzUblSN9pVztZlPRiOEREdcN1y/pFmAVsCwiolJNRGwGNqf6B4HDwCVkIbBXEmRLU89JWhIRr0taCGwCro+IN9NQ1wEvR8SxNFYn8MtAxfCIiI2k/ZJCoVBxbmZ5NTc1UqwQFM1NjRMwG7OJUeurrVaQ7Vd8IiKOD1M3O/09n2y/439HRE9EzI6IiyLiIrJAuTIFx3ygE7gpIg6VDfUqcJWkc5UlzjLgQC3HYJZXW2sLjTMaTmlrnNFAW2vLBM3IbPyNeOUxgkeAc4Dt6ephR0TcLqkZ2BQRK1Pd45JmAv3AHRHRN8K49wMzgUfTuCciohAROyV9BXiObJlsN+nKwmy8rFk8B8j2Po70lWhuaqStteVku9l0oCorTVNOoVCI7u7uiZ6GmdmkIWlXRBQq9fk3zM3MLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLDeHh5mZ5ebwMDOz3BweZmaWm8PDzMxyc3iYmVlutX6eh9m42rq76M/RMDsDODxs0ti6u0h7Zw+l/gEAin0l2jt7ABwgZuPMy1Y2aXR09Z4MjkGl/gE6unonaEZm05fDwyaNI32lXO1mNnZqDg9JHZIOStonaYukpip1d0raL+l5SXdV6L9bUkialW6vTmPukdQt6eqy2pslvZD+3FzrMdjk0NzUmKvdzMZOPa48tgMLImIhcAhoH1ogaQFwG7AEWASsknRpWf88YDnwatndvgEsioiPAOuATan2/cDvAL+YxvsdSefX4TjsDNfW2kLjjIZT2hpnNNDW2jJBMzKbvmoOj4jYFhEn0s0dwNwKZZcBOyPieKp9Blhb1v8wcA8QZeP+JCIGb59X1tcKbI+IH0bEW2ThtaLW47Az35rFc/j82iuY09SIgDlNjXx+7RXeLDebAPV+tdU64MsV2vcDvy9pJlACVgLdkC1PAcWI2CvplDtJ+iTweWA28KupeQ7w/bKyw6ntHSStB9YDzJ8///SOyM4oaxbPcViYnQFGFR6SngYurNC1ISKeSDUbgBPAY0OLIuKApIeAbcDbwB5gQNK5wH1kS1bvEBFbgC2SrgUeAK4bzXzL7r8R2AhQKBRihHIzMxulUYVHRAz7Q1vSLcAqYFnZUtPQMTYDm1P9g2RXDJcAFwODVx1zgeckLYmI18vu+21JH0qb6UXgY2VDzwX+fjTHYWZm9VHzspWkFWT7FUsj4vgwdbMj4qik+WT7HVdFRB/ZktRgzStAISLeSBvqL0VESLoSOAd4E+gCHizbJF9OhU16MzMbO/XY83iE7Af79nT1sCMibpfUDGyKiJWp7vG059EP3JGCYzifAj4jqZ9sn+TT6armh5IeAL6T6n4vIn5Yh+MwM7NRUpVVpimnUChEd3f3RE/DzGzSkLQrIgqV+vwb5mZmlpvDw8zMcnN4mJlZbg4PMzPLzeFhZma5OTzMzCw3h4eZmeXm8DAzs9wcHmZmllu935Ldpqitu4t0dPVypK9Ec1Mjba0tfmt0s2nM4WEj2rq7SHtnD6X+AQCKfSXaO3sAHCBm05SXrWxEHV29J4NjUKl/gI6u3gmakZlNNIeHjehIXylXu5lNfQ4PG1FzU2OudjOb+hweNqK21hYaZzSc0tY4o4G21pYJmpGZTTRvmNuIBjfF/WorMxvk8LBRWbN4jsPCzE6qadlKUoekg5L2SdoiqalK3Z2S9kt6XtJdFfrvlhSSZqXbq9OYeyR1S7o6tX9E0v9N4+yT9Ola5m9mZqen1j2P7cCCiFgIHALahxZIWgDcBiwBFgGrJF1a1j8PWA68Wna3bwCLIuIjwDpgU2o/DnwmIn4eWAH8SbXAMjOzsVNTeETEtog4kW7uAOZWKLsM2BkRx1PtM8Dasv6HgXuAkx+mHhE/iX/5cPXzBvsi4lBEvJC+PgIcBS6o5RjMzCy/er7aah3wVIX2/cA1kmZKOhdYCcyDbHkKKEbE3qF3kvRJSQeBr6exh/YvAc4GXqo2IUnr07JX97Fjx07nmMzMrIIRN8wlPQ1cWKFrQ0Q8kWo2ACeAx4YWRcQBSQ8B24C3gT3AQAqS+8iWrN4hIrYAWyRdCzwAXFc2pw8CfwncHBE/qzb3iNgIbAQoFApRrc7MzPIZMTwi4rrh+iXdAqwClpUtNQ0dYzOwOdU/CBwGLgEuBvZKgmzJ6zlJSyLi9bL7flvShyTNiog3JL2X7GpkQ0TsGMUxmplZndX0Ul1JK8j2K5ZGxPFh6mZHxFFJ88n2O66KiD5gdlnNK0AhBcSlwEsREZKuBM4B3pR0NrAF+IuI+Eotczczs9NX6+95PEL2g317unrYERG3S2oGNkXEylT3uKSZQD9wRwqO4XwK+IykfqAEfDoFya8B1wIz0xUPwC0RsafG4zAzsxxUZaVpyikUCtHd3T3R0zAzmzQk7YqIQqU+v7eVmZnl5vAwM7PcHB5mZpabw8PMzHJzeJiZWW5+S/ZJYOvuoj9Lw8zOKA6PM9zW3UXaO3so9Q8AUOwr0d7ZA+AAMbMJ42WrM1xHV+/J4BhU6h+go6t3gmZkZubwOOMd6SvlajczGw8OjzNcc1NjrnYzs/Hg8DjDtbW20Dij4ZS2xhkNtLW2TNCMzMy8YX7GG9wU96utzOxM4vCYBNYsnuOwMLMzipetzMwsN4eHmZnl5vAwM7PcHB5mZpZbzeEhqUPSQUn7JG2R1FSl7k5J+yU9L+muCv13SwpJs9Lt1WnMPZK6JV09pP69kg5LeqTWYzAzs3zqceWxHVgQEQuBQ0D70AJJC4DbgCXAImCVpEvL+ucBy4FXy+72DWBRRHwEWAdsGjLsA8C36zB/MzPLqebwiIhtEXEi3dwBzK1QdhmwMyKOp9pngLVl/Q8D9wAnP1A9In4S//IB6+eV90n6BeADwLZa529mZvnVe89jHfBUhfb9wDWSZko6F1gJzINseQooRsTeoXeS9ElJB4Gvp7GR9HPAHwGfq/PczcxslEb1S4KSngYurNC1ISKeSDUbgBPAY0OLIuKApIfIrhTeBvYAAylI7iNbsnqHiNgCbJF0Ldky1XXAbwNPRsRhSSPNez2wHmD+/PkjH6iZmY2K/mVlqIZBpFuA3wKWRcTxUdQ/CBwG/oFsb2PwPnOBI8CSiHh9yH2+R7Zn8qfANcDPgHcDZwOPRsS9wz1moVCI7u7uHEdlZja9SdoVEYVKfTW/PYmkFWT7FUuHCw5JsyPiqKT5ZPsdV0VEHzC7rOYVoBARb6QN9ZciIiRdCZwDvBkRN5bV35Lqhw0OMzOrr3q8t9UjZD/Yt6dlpB0RcbukZmBTRKxMdY9Lmgn0A3ek4BjOp4DPSOoHSsCnox6XSWZmVrO6LFtNBl62MjPLZ7hlK/+GuZmZ5ea3ZB/G1t1Ff46GmVkFDo8qtu4u0t7ZQ6l/AIBiX4n2zh4AB4iZTXtetqqio6v3ZHAMKvUP0NHVO0EzMjM7czg8qjjSV8rVbmY2nTg8qmhuaszVbmY2nTg8qmhrbaFxRsMpbY0zGmhrbZmgGZmZnTm8YV7F4Ka4X21lZvZODo9hrFk8x2FhZlaBl63MzCw3h4eZmeXm8DAzs9wcHmZmlpvDw8zMcps2b8ku6Rjwj6d591nAG3WcTr14Xvl4Xvl4XvlMxXn9q4i4oFLHtAmPWkjqrvae9hPJ88rH88rH88pnus3Ly1ZmZpabw8PMzHJzeIzOxomeQBWeVz6eVz6eVz7Tal7e8zAzs9x85WFmZrk5PMzMLDeHRyLp30p6XtLPJBWG9LVLelFSr6TWKve/WNLOVPdlSWePwRy/LGlP+vOKpD1V6l6R1JPquus9jwqP97uSimVzW1mlbkU6hy9Kuncc5tUh6aCkfZK2SGqqUjcu52uk45d0Tvoev5ieSxeN1VzKHnOepG9J+m56/t9ZoeZjkn5U9v29f6znlR532O+LMv8tna99kq4chzm1lJ2HPZJ+LOmuITXjcr4kfVHSUUn7y9reL2m7pBfS3+dXue/NqeYFSTef1gQiwn+yfZ/LgBbg74FCWfvlwF7gHOBi4CWgocL9/w9wQ/r6C8B/GOP5/hFwf5W+V4BZ43jufhf43Ag1DencfQg4O53Ty8d4XsuBs9LXDwEPTdT5Gs3xA78NfCF9fQPw5XH43n0QuDJ9/R7gUIV5fQz42ng9n0b7fQFWAk8BAq4Cdo7z/BqA18l+kW7czxdwLXAlsL+s7Q+Be9PX91Z6zgPvB76X/j4/fX1+3sf3lUcSEQciordC12rgSxHxzxHxMvAisKS8QJKAXwG+kpr+F7BmrOaaHu/XgL8eq8cYA0uAFyPiexHxU+BLZOd2zETEtog4kW7uAOaO5eONYDTHv5rsuQPZc2lZ+l6PmYh4LSKeS1//E3AAmCwfYrMa+IvI7ACaJH1wHB9/GfBSRJzuO1fUJCK+DfxwSHP5c6jaz6FWYHtE/DAi3gK2AyvyPr7DY2RzgO+X3T7MO/9xzQT6yn5QVaqpp2uAH0TEC1X6A9gmaZek9WM4j3KfTUsHX6xyqTya8ziW1pH9L7WS8Thfozn+kzXpufQjsufWuEjLZIuBnRW6f0nSXklPSfr5cZrSSN+XiX5O3UD1/8BNxPkC+EBEvJa+fh34QIWaupy3afVJgpKeBi6s0LUhIp4Y7/lUMso5/jrDX3VcHRFFSbOB7ZIOpv+ljMm8gD8HHiD7x/4A2ZLauloerx7zGjxfkjYAJ4DHqgxT9/M12Uh6N/A4cFdE/HhI93NkSzM/SftZW4EPj8O0ztjvS9rT/ATQXqF7os7XKSIiJI3Z72JMq/CIiOtO425FYF7Z7bmprdybZJfMZ6X/MVaqqcscJZ0FrAV+YZgxiunvo5K2kC2Z1PSPbrTnTtJ/B75WoWs057Hu85J0C7AKWBZpwbfCGHU/XxWM5vgHaw6n7/P7yJ5bY0rSDLLgeCwiOof2l4dJRDwp6VFJsyJiTN8EcBTflzF5To3S9cBzEfGDoR0Tdb6SH0j6YES8lpbwjlaoKZLtywyaS7bXm4uXrUb2VeCG9EqYi8n+B/H/ygvSD6VvAf8mNd0MjNWVzHXAwYg4XKlT0nmS3jP4Ndmm8f5KtfUyZJ35k1Ue7zvAh5W9Ku1sskv+r47xvFYA9wCfiIjjVWrG63yN5vi/Svbcgey59M1qgVcvaU9lM3AgIv64Ss2Fg3svkpaQ/dwY01Ab5fflq8Bn0quurgJ+VLZkM9aqXv1PxPkqU/4cqvZzqAtYLun8tMS8PLXlM9avCJgsf8h+6B0G/hn4AdBV1reB7JUyvcD1Ze1PAs3p6w+RhcqLwN8A54zRPP8ncPuQtmbgybJ57E1/nidbvhnrc/eXQA+wLz15Pzh0Xun2SrJX87w0TvN6kWxtd0/684Wh8xrP81Xp+IHfIws3gHel586L6bn0oXE4R1eTLTfuKztPK4HbB59nwGfTudlL9sKDXx6HeVX8vgyZl4A/S+ezh7JXSY7x3M4jC4P3lbWN+/kiC6/XgP70s+tWsj2ybwAvAE8D70+1BWBT2X3XpefZi8C/P53H99uTmJlZbl62MjOz3BweZmaWm8PDzMxyc3iYmVluDg8zM8vN4WFmZrk5PMzMLLf/D81m18qf8OZTAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "x = 90\n",
-    "plt.scatter(thetas[x : x + 10, 0], thetas[x : x + 10, 1])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray([[-2.9434702 , -1.0610158 , -0.91644555],\n",
-       "             [-2.9433036 , -1.0609921 , -0.9164234 ],\n",
-       "             [-2.943137  , -1.0609684 , -0.91640127],\n",
-       "             [-2.9429703 , -1.0609446 , -0.916379  ],\n",
-       "             [-2.9428034 , -1.0609208 , -0.91635674],\n",
-       "             [-2.9426367 , -1.0608972 , -0.91633445],\n",
-       "             [-2.94247   , -1.0608734 , -0.9163123 ],\n",
-       "             [-2.9423037 , -1.0608497 , -0.91629004],\n",
-       "             [-2.942137  , -1.060826  , -0.9162678 ],\n",
-       "             [-2.9419703 , -1.0608022 , -0.91624564]], dtype=float32)"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "thetas[x : x + 10]\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/alexconstantino/.local/share/virtualenvs/research-pVCP8Qup/lib/python3.8/site-packages/jax/_src/tree_util.py:185: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
-      "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "import numpyro\n",
-    "import numpyro.distributions as dist\n",
-    "from numpyro.infer import MCMC, NUTS\n",
-    "\n",
-    "\n",
-    "def mcmc_berry_model(y, n):\n",
-    "    mu = numpyro.sample(\"mu\", dist.Normal(-1.34, 10))\n",
-    "    sigma2 = numpyro.sample(\"sigma2\", dist.InverseGamma(0.0005, 0.000005))\n",
-    "    with numpyro.plate(\"j\", 2):\n",
-    "        theta = numpyro.sample(\n",
-    "            \"theta\",\n",
-    "            dist.Normal(mu, jax.numpy.sqrt(sigma2)),\n",
-    "        )\n",
-    "        numpyro.sample(\n",
-    "            \"y\",\n",
-    "            dist.BinomialLogits(theta + (np.log(0.3) - np.log(1 - 0.3)), total_count=n),\n",
-    "            obs=y,\n",
-    "        )\n",
-    "\n",
-    "\n",
-    "def do_mcmc(rng_key, y, n):\n",
-    "    nuts_kernel = NUTS(mcmc_berry_model)\n",
-    "    mcmc = MCMC(\n",
-    "        nuts_kernel,\n",
-    "        progress_bar=False,\n",
-    "        num_warmup=10_000,\n",
-    "        num_samples=1_000_000,\n",
-    "        thinning=10,\n",
-    "    )\n",
-    "    mcmc.run(rng_key, y, n)\n",
-    "    return mcmc.get_samples(group_by_chain=True)\n",
-    "\n",
-    "\n",
-    "s = do_mcmc(jax.random.PRNGKey(0), jnp.array([4, 8]), jnp.array([35, 35]))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.06822955]\n",
-      "(100000,)\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbsAAAE9CAYAAACSgMzbAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAaaklEQVR4nO3df2xV9f3H8deFTiPKr04uNL0NHd4Kpe21wm2p02GwXiotK0E2pNa0BLVb1TTqomM/YOsyZ2fioguQ7TrmWjUiaqRG29I5ZQ5mqRdsHDRuV6Wzt9zVoq2Ak1/l8/2DeL+rSFv6w3v58HwkJO3n3nvu+zbKk3Pv6TkOY4wRAAAWGxPtAQAAGG3EDgBgPWIHALAesQMAWI/YAQCsR+wAANaLi/YAQ3XppZcqOTk52mMAAGJEW1ubDhw48KW3nbOxS05OViAQiPYYAIAY4fV6z3gbb2MCAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrnbPnxsToSl79crRH6KOtqiDaIwA4h7FnBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArMe5MXFOiKVzdXKeTuDcw54dAMB6A8auvb1dCxYs0OzZs5WWlqZHH31UkvTxxx/L5/MpJSVFPp9P3d3dkiRjjCoqKuR2u+XxeLR79+7Itqqrq5WSkqKUlBRVV1dH1nft2qWMjAy53W5VVFTIGDPSrxMAcB4bMHZxcXF6+OGH1draqqamJq1fv16tra2qqqpSbm6ugsGgcnNzVVVVJUmqr69XMBhUMBiU3+9XeXm5pFNxrKys1M6dO9Xc3KzKyspIIMvLy/XYY49FHtfQ0DCKLxkAcL4ZMHYJCQmaM2eOJGn8+PFKTU1VR0eHamtrVVpaKkkqLS3Vli1bJEm1tbUqKSmRw+FQTk6Oenp6FA6HtXXrVvl8PsXHx2vy5Mny+XxqaGhQOBzWwYMHlZOTI4fDoZKSksi2AAAYCWd1gEpbW5veeustzZs3T52dnUpISJAkTZs2TZ2dnZKkjo4OJSUlRR7jcrnU0dHR77rL5Tpt/cv4/X75/X5JUldX19mMDgA4jw36AJXDhw9r2bJleuSRRzRhwoQ+tzkcDjkcjhEf7ovKysoUCAQUCAQ0ZcqUUX8+AIAdBhW748ePa9myZSouLtaNN94oSZo6darC4bAkKRwOy+l0SpISExPV3t4eeWwoFFJiYmK/66FQ6LR1AABGyoCxM8bo1ltvVWpqqu69997IemFhYeSIyurqai1ZsiSyXlNTI2OMmpqaNHHiRCUkJCgvL0+NjY3q7u5Wd3e3GhsblZeXp4SEBE2YMEFNTU0yxqimpiayLQAARsKAn9nt2LFDTzzxhDIyMpSZmSlJ+tWvfqXVq1dr+fLl2rhxo6ZPn67NmzdLkvLz81VXVye3261x48bp8ccflyTFx8drzZo1ysrKkiStXbtW8fHxkqQNGzZo5cqV+uyzz7Ro0SItWrRoNF4rAOA85TDn6C+1eb1eBQKBaI9hrVg6Y0ms4QwqQGzqrwucQQUAYD1iBwCwHieCjiG8dQgAo4M9OwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArBcX7QGiKXn1y9EeAQDwFWDPDgBgPWIHALAesQMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHrEDgBgPWIHALAesQMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHrEDgBgvQFjt2rVKjmdTqWnp0fWfv7znysxMVGZmZnKzMxUXV1d5LYHH3xQbrdbM2fO1NatWyPrDQ0Nmjlzptxut6qqqiLr+/bt07x58+R2u3XTTTfp2LFjI/XaAACQNIjYrVy5Ug0NDaet33PPPWppaVFLS4vy8/MlSa2trdq0aZP27t2rhoYG3XHHHert7VVvb6/uvPNO1dfXq7W1VU8//bRaW1slST/84Q91zz336N1339XkyZO1cePGEX6JAIDz3YCxmz9/vuLj4we1sdraWq1YsUIXXnihvvGNb8jtdqu5uVnNzc1yu92aMWOGLrjgAq1YsUK1tbUyxujVV1/Vd77zHUlSaWmptmzZMqwXBADAFw35M7t169bJ4/Fo1apV6u7uliR1dHQoKSkpch+Xy6WOjo4zrn/00UeaNGmS4uLi+qwDADCShhS78vJyvffee2ppaVFCQoJ+8IMfjPRcX8rv98vr9crr9aqrq+sreU4AwLlvSLGbOnWqxo4dqzFjxuj2229Xc3OzJCkxMVHt7e2R+4VCISUmJp5x/etf/7p6enp04sSJPutnUlZWpkAgoEAgoClTpgxldADAeWhIsQuHw5GvX3jhhciRmoWFhdq0aZOOHj2qffv2KRgMKjs7W1lZWQoGg9q3b5+OHTumTZs2qbCwUA6HQwsWLNBzzz0nSaqurtaSJUtG4GUBAPD/4ga6Q1FRkbZt26YDBw7I5XKpsrJS27ZtU0tLixwOh5KTk/X73/9ekpSWlqbly5dr9uzZiouL0/r16zV27FhJpz7jy8vLU29vr1atWqW0tDRJ0q9//WutWLFCP/3pT3XllVfq1ltvHcWXCwA4HzmMMSbaQwyF1+tVIBAY1jaSV788QtPgfNJWVRDtEQB8if66wBlUAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFiP2AEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFhvwIu3Augr1q6DyPX1gIGxZwcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKw3YOxWrVolp9Op9PT0yNrHH38sn8+nlJQU+Xw+dXd3S5KMMaqoqJDb7ZbH49Hu3bsjj6murlZKSopSUlJUXV0dWd+1a5cyMjLkdrtVUVEhY8xIvj4AAAaO3cqVK9XQ0NBnraqqSrm5uQoGg8rNzVVVVZUkqb6+XsFgUMFgUH6/X+Xl5ZJOxbGyslI7d+5Uc3OzKisrI4EsLy/XY489FnncF58LAIDhGjB28+fPV3x8fJ+12tpalZaWSpJKS0u1ZcuWyHpJSYkcDodycnLU09OjcDisrVu3yufzKT4+XpMnT5bP51NDQ4PC4bAOHjyonJwcORwOlZSURLYFAMBIGdJndp2dnUpISJAkTZs2TZ2dnZKkjo4OJSUlRe7ncrnU0dHR77rL5TptHQCAkRQ33A04HA45HI6RmGVAfr9ffr9fktTV1fWVPCcA4Nw3pD27qVOnKhwOS5LC4bCcTqckKTExUe3t7ZH7hUIhJSYm9rseCoVOWz+TsrIyBQIBBQIBTZkyZSijAwDOQ0OKXWFhYeSIyurqai1ZsiSyXlNTI2OMmpqaNHHiRCUkJCgvL0+NjY3q7u5Wd3e3GhsblZeXp4SEBE2YMEFNTU0yxqimpiayLQAARsqAb2MWFRVp27ZtOnDggFwulyorK7V69WotX75cGzdu1PTp07V582ZJUn5+vurq6uR2uzVu3Dg9/vjjkqT4+HitWbNGWVlZkqS1a9dGDnrZsGGDVq5cqc8++0yLFi3SokWLRuu1AgDOUw5zjv5im9frVSAQGNY2kle/PELTANHTVlUQ7RGAmNBfFziDCgDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKwXF+0BAAxP8uqXoz1CH21VBdEeATgNe3YAAOsROwCA9YgdAMB6xA4AYD1iBwCwHrEDAFhvWLFLTk5WRkaGMjMz5fV6JUkff/yxfD6fUlJS5PP51N3dLUkyxqiiokJut1sej0e7d++ObKe6ulopKSlKSUlRdXX1cEYCAOA0w96ze+2119TS0qJAICBJqqqqUm5uroLBoHJzc1VVVSVJqq+vVzAYVDAYlN/vV3l5uaRTcaysrNTOnTvV3NysysrKSCABABgJI/42Zm1trUpLSyVJpaWl2rJlS2S9pKREDodDOTk56unpUTgc1tatW+Xz+RQfH6/JkyfL5/OpoaFhpMcCAJzHhhU7h8OhhQsXau7cufL7/ZKkzs5OJSQkSJKmTZumzs5OSVJHR4eSkpIij3W5XOro6Djj+pfx+/3yer3yer3q6uoazugAgPPIsE4Xtn37diUmJurDDz+Uz+fTrFmz+tzucDjkcDiGNeD/KisrU1lZmSRFPiMEAGAgw9qzS0xMlCQ5nU4tXbpUzc3Nmjp1qsLhsCQpHA7L6XRG7tve3h55bCgUUmJi4hnXAQAYKUOO3aeffqpDhw5Fvm5sbFR6eroKCwsjR1RWV1dryZIlkqTCwkLV1NTIGKOmpiZNnDhRCQkJysvLU2Njo7q7u9Xd3a3Gxkbl5eWNwEsDAOCUIb+N2dnZqaVLl0qSTpw4oZtvvlk33HCDsrKytHz5cm3cuFHTp0/X5s2bJUn5+fmqq6uT2+3WuHHj9Pjjj0uS4uPjtWbNGmVlZUmS1q5dq/j4+OG+LgAAIhzGGBPtIYbC6/VGft1hqGLt0iiADbjED6Klvy5wBhUAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1ouL9gAA7JK8+uVojxDRVlUQ7REQI9izAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB6xAwBYj9gBAKxH7AAA1iN2AADrETsAgPWIHQDAesQOAGA9YgcAsB4XbwVgrVi6kKzExWSjiT07AID1iB0AwHoxE7uGhgbNnDlTbrdbVVVV0R4HAGCRmIhdb2+v7rzzTtXX16u1tVVPP/20Wltboz0WAMASMRG75uZmud1uzZgxQxdccIFWrFih2traaI8FALBETByN2dHRoaSkpMj3LpdLO3fujOJEADDyYuno0PPtyNCYiN1g+f1++f1+SdI777wjr9c7rO1dOsTHdXV1acqUKcN67q8S844u5h1dzDs6vN6fSTp35v1cf/O2tbWd8XExEbvExES1t7dHvg+FQkpMTDztfmVlZSorK/sqR/tSXq9XgUAg2mMMGvOOLuYdXcw7us6XeWPiM7usrCwFg0Ht27dPx44d06ZNm1RYWBjtsQAAloiJPbu4uDitW7dOeXl56u3t1apVq5SWlhbtsQAAloiJ2ElSfn6+8vPzoz3GoMTCW6lng3lHF/OOLuYdXefLvA5jjBnhWQAAiCkx8ZkdAACjidgN0Zo1a+TxeJSZmamFCxdq//790R6pX/fdd59mzZolj8ejpUuXqqenJ9oj9evZZ59VWlqaxowZE9NHip1Lp7lbtWqVnE6n0tPToz3KoLS3t2vBggWaPXu20tLS9Oijj0Z7pH4dOXJE2dnZuuKKK5SWlqaf/exn0R5pUHp7e3XllVdq8eLF0R5lQMnJycrIyFBmZubZ/+qZwZB88sknka8fffRR873vfS+K0wxs69at5vjx48YYY+6//35z//33R3mi/rW2tpp33nnHXHvttebNN9+M9jhf6sSJE2bGjBnmvffeM0ePHjUej8fs3bs32mOd0V//+leza9cuk5aWFu1RBmX//v1m165dxhhjDh48aFJSUmL653vy5Elz6NAhY4wxx44dM9nZ2eaNN96I8lQDe/jhh01RUZEpKCiI9igDmj59uunq6hrSY9mzG6IJEyZEvv7000/lcDiiOM3AFi5cqLi4U8cj5eTkKBQKRXmi/qWmpmrmzJnRHqNf59pp7ubPn6/4+PhojzFoCQkJmjNnjiRp/PjxSk1NVUdHR5SnOjOHw6FLLrlEknT8+HEdP3485v9eCIVCevnll3XbbbdFe5RRR+yG4Sc/+YmSkpL01FNP6Re/+EW0xxm0P/7xj1q0aFG0xzjnfdlp7mL5L+NzWVtbm9566y3Nmzcv2qP0q7e3V5mZmXI6nfL5fDE/7913362HHnpIY8acGylwOBxauHCh5s6dGzmb1mCdG68wSq6//nqlp6ef9ufzf70/8MADam9vV3FxsdatWxflaQeeVzo1c1xcnIqLi6M46SmDmRc4fPiwli1bpkceeaTPOyqxaOzYsWppaVEoFFJzc7P27NkT7ZHO6KWXXpLT6dTcuXOjPcqgbd++Xbt371Z9fb3Wr1+v119/fdCPjZnfs4tFr7zyyqDuV1xcrPz8fFVWVo7yRP0baN4//elPeumll/SXv/wlJt5eGezPN1YN9jR3GLrjx49r2bJlKi4u1o033hjtcQZt0qRJWrBggRoaGmL2gKAdO3boxRdfVF1dnY4cOaKDBw/qlltu0ZNPPhnt0c7o8/+/nE6nli5dqubmZs2fP39Qj2XPboiCwWDk69raWs2aNSuK0wysoaFBDz30kF588UWNGzcu2uNYgdPcjS5jjG699Valpqbq3nvvjfY4A+rq6ooc5fzZZ5/pz3/+c0z/vfDggw8qFAqpra1NmzZt0nXXXRfTofv000916NChyNeNjY1n9Q8JYjdEq1evVnp6ujwejxobG2P+sOi77rpLhw4dks/nU2Zmpr7//e9He6R+vfDCC3K5XHrjjTdUUFCgvLy8aI90mv89zV1qaqqWL18e06e5Kyoq0lVXXaV//vOfcrlc2rhxY7RH6teOHTv0xBNP6NVXX1VmZqYyMzNVV1cX7bHOKBwOa8GCBfJ4PMrKypLP5zsnDuc/V3R2duqaa67RFVdcoezsbBUUFOiGG24Y9OM5gwoAwHrs2QEArEfsAADWI3YAAOsROwCA9YgdAMB6xA4YhM/PeTgU69atk9vtlsPh0IEDByLrxhhVVFTI7XbL4/Fo9+7dkdvC4fCAh61/85vfHPJMZ+PEiRMqKCjQpZdeetoZQc50NY1//OMfWrly5VcyHzAYxA4YZVdffbVeeeUVTZ8+vc96fX29gsGggsGg/H6/ysvLI7f95je/0e23397vdv/+97+PyrxfVF5erlmzZmnLli266aab+pxE3Ofzac+ePXr77bd1+eWX68EHH5QkZWRkKBQK6YMPPvhKZgQGQuyAs2CM0X333af09HRlZGTomWeekSSdPHlSd9xxh2bNmiWfz6f8/Hw999xzkqQrr7xSycnJp22rtrZWJSUlcjgcysnJUU9Pj8LhsCTp+eefj/zC7N69e5Wdna3MzEx5PJ7I2Xs+39vs77mTk5P1ox/9KHL9r927dysvL0+XXXaZfve730k6de7J3NxczZkzRxkZGX3OTVpZWamJEyfq4Ycf1jXXXKM//OEPKioq0ieffCKp/6tpfPvb39amTZtG5gcPDNfIXWkIsNfFF19sjDHmueeeM9dff705ceKE+c9//mOSkpLM/v37zbPPPmsWLVpkent7TTgcNpMmTTLPPvtsn2188VpcBQUF5m9/+1vk++uuu868+eab5v333zdz5syJrN91113mySefNMYYc/ToUfPf//63z0z9Pff06dPNhg0bjDHG3H333SYjI8McPHjQfPjhh8bpdBpjjDl+/Hjk+oxdXV3msssuMydPnjzrn9HixYvNE088Efl++/btZvHixWe9HWA0cCJo4Cxs375dRUVFGjt2rKZOnaprr71Wb775prZv367vfve7GjNmjKZNm6YFCxYM+TnC4bCmTJkS+f6qq67SAw88oFAopBtvvFEpKSmnzdTfc39+vs6MjAwdPnxY48eP1/jx43XhhReqp6dHF198sX784x/r9ddf15gxY9TR0aHOzk5NmzZt0DN/2dU0nE6n9u/fP5QfATDieBsTiJIzXTXhoosu0pEjRyLrN998s1588UVddNFFys/P16uvvnpWz3PhhRdKksaMGRP5+vPvT5w4oaeeekpdXV3atWuXWlpaNHXq1D7PP5DPr6bx1FNP9bmaxpEjR3TRRRed1azAaCF2wFn41re+pWeeeUa9vb3q6urS66+/ruzsbF199dV6/vnndfLkSXV2dmrbtm0DbquwsFA1NTUyxqipqUkTJ05UQkKCLr/8crW1tUXu9/7772vGjBmqqKjQkiVL9Pbbb/fZzlCe+3998skncjqd+trXvqbXXntN//73vwf92P6upvGvf/0rZi9vg/MPsQPOwtKlS+XxeHTFFVfouuuu00MPPaRp06Zp2bJlcrlcmj17tm655RbNmTNHEydOlCT99re/lcvlUigUksfj0W233SZJys/P14wZM+R2u3X77bdrw4YNkqSLL75Yl112md59911J0ubNm5Wenq7MzEzt2bNHJSUlfWbq77kHo7i4WIFAQBkZGaqpqTmry9L0dzWN1157TQUFBYPeFjCauOoBMEIOHz6sSy65RB999JGys7O1Y8eOs/rc63+98MIL2rVrl375y19+5c89Eo4ePaprr71W27dvjxytCUQT/xUCI2Tx4sXq6enRsWPHtGbNmmHFZunSpfroo4+i8twj4YMPPlBVVRWhQ8xgzw4AYD0+swMAWI/YAQCsR+wAANYjdgAA6xE7AID1iB0AwHr/B6De37a9tSTBAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 504x360 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "sig = s[\"sigma2\"]\n",
-    "# sig = sig[np.newaxis]\n",
-    "sig = sig[:, :][0]\n",
-    "print(np.quantile(sig, [0.5]))\n",
-    "sig = np.log10(sig)\n",
-    "print(sig.shape)\n",
-    "fig = plt.figure(figsize=(7, 5))\n",
-    "plt.hist(sig, bins=10)\n",
-    "plt.xlabel(\"log10(sigma^2)\")\n",
-    "fig.patch.set_alpha(1)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def jax_calc_posterior_and_exceedances(\n",
-    "    theta_max,\n",
-    "    y,\n",
-    "    n,\n",
-    "    log_prior,\n",
-    "    neg_precQ,\n",
-    "    logprecQdet,\n",
-    "    hess_inv,\n",
-    "    sigma2_wts,\n",
-    "    logit_p1,\n",
-    "    mu_0,\n",
-    "    thresh_theta,\n",
-    "):\n",
-    "    theta_m0 = theta_max - mu_0\n",
-    "    theta_adj = theta_max + logit_p1\n",
-    "    exp_theta_adj = jnp.exp(theta_adj)\n",
-    "    logjoint = (\n",
-    "        0.5 * jnp.einsum(\"...i,...ij,...j\", theta_m0, neg_precQ, theta_m0)\n",
-    "        + logprecQdet\n",
-    "        + jnp.sum(\n",
-    "            theta_adj * y[:, None] - n[:, None] * jnp.log(exp_theta_adj + 1),\n",
-    "            axis=-1,\n",
-    "        )\n",
-    "        + log_prior\n",
-    "    )\n",
-    "\n",
-    "    log_sigma2_post = logjoint + 0.5 * jnp.log(jnp.linalg.det(-hess_inv))\n",
-    "    sigma2_post = jnp.exp(log_sigma2_post)\n",
-    "    sigma2_post /= jnp.sum(sigma2_post * sigma2_wts, axis=1)[:, None]\n",
-    "\n",
-    "    theta_sigma = jnp.sqrt(jnp.diagonal(-hess_inv, axis1=2, axis2=3))\n",
-    "    exc_sigma2 = 1.0 - jax.scipy.stats.norm.cdf(\n",
-    "        thresh_theta,\n",
-    "        theta_max,\n",
-    "        theta_sigma,\n",
-    "    )\n",
-    "    exceedances = jnp.sum(\n",
-    "        exc_sigma2 * sigma2_post[:, :, None] * sigma2_wts[None, :, None], axis=1\n",
-    "    )\n",
-    "    return sigma2_post, exceedances\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3.10.5 ('kevlar')",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.5"
-  },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "b6bd0657068c38953c2fe5251f8f61893d47205eb021f5d049a4c9233ce79361"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/research/berry/jax_inla.md
+++ b/research/berry/jax_inla.md
@@ -43,7 +43,7 @@ fi = FastINLA(n_arms=2)
 # # fi.jax_inference(y, n)
 
 
-def jax_faster_invert(D, S):
+def jax_faster_inv(D, S):
     """Compute the inverse of a diagonal matrix D plus a shift S.
 
     This function uses "Sherman-Morrison" formula:
@@ -84,7 +84,7 @@ def jax_opt(y, neg_precQ, fast_loop=True):
         reg = jnp.sqrt(H * jnp.linalg.norm(grad))
         diag += reg
 
-        hess_inv = jax_faster_invert(diag, shift)
+        hess_inv = jax_faster_inv(diag, shift)
         step = -hess_inv.dot(grad)
 
         probit_step = 1 / (1 + jnp.exp(-theta_max))
@@ -117,7 +117,7 @@ def jax_opt(y, neg_precQ, fast_loop=True):
 # def run(y, i):
 #     # cov = jnp.full((fi.n_arms, fi.n_arms), fi.mu_sig_sq)
 #     # cov = cov + jnp.diag(jnp.full(fi.n_arms, sigma2))
-#     # # shift, prec_d = berrylib.fast_inla.jax_faster_invert(jnp.repeat(sigma2, arms), 100)
+#     # # shift, prec_d = berrylib.fast_inla.jax_faster_inv(jnp.repeat(sigma2, arms), 100)
 #     # # neg_precQ = -(jnp.diag(prec_d) + shift)
 #     # neg_precQ = jnp.linalg.inv(cov)
 #     n = np.array([[35, 35]])


### PR DESCRIPTION
We replace the current slogdet call (which requires pivoting) with a
GPU-friendly, numerically stable, and faster implementation that uses
the matrix determinant lemma:
https://en.wikipedia.org/wiki/Matrix_determinant_lemma

This further reduces runtime from ~10us to ~7us.